### PR TITLE
Support zone stop command on Gen-1 devices

### DIFF
--- a/regenmaschine/zone.py
+++ b/regenmaschine/zone.py
@@ -48,4 +48,5 @@ class Zones(api.BaseAPI):
 
     def stop(self, zone_id):
         """ Stops a zone """
-        return self.parent.post('zone/{}/stop'.format(zone_id)).object.json()
+        return self.parent.post('zone/{}/stop'.format(zone_id), json={'zid':
+                                                                      zone_id}).object.json()


### PR DESCRIPTION
Possibly others.  I'd guess this probably isn't required for more recent hardware but I don't imagine including the json payload would cause any issues if it isn't needed.