### PR TITLE
Use 3.5 (not 3.6) as the minimum Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 ---
 sudo: false
 language: python
-python:
-  - "3.5"
-  - "3.6"
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.5.3"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
 install: "make init"
 script: "make ci"
-cache: "pip"
+cache:
+  directories:
+    - $HOME/.cache/pip
 jobs:
   include:
     - stage: "coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 sudo: false
 language: python
 python:
+  - "3.5"
   - "3.6"
 install: "make init"
 script: "make ci"

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Version 1.0.0 of Regenmaschine makes several breaking, but necessary changes:
   `Requests <http://docs.python-requests.org/en/master/>`_ to
   `aiohttp <https://aiohttp.readthedocs.io/en/stable/>`_
 * Changes the entire library to use :code:`asyncio`
-* Makes 3.6 the minimum version of Python required
+* Makes 3.5 the minimum version of Python required
 
 If you wish to continue using the previous, synchronous version of
 Regenmaschine, make sure to pin version 0.4.2.

--- a/regenmaschine/__version__.py
+++ b/regenmaschine/__version__.py
@@ -1,2 +1,2 @@
 """Define the package version."""
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DESCRIPTION = 'A simple API for RainMachine sprinkler controllers'
 URL = 'https://github.com/bachya/regenmaschine'
 EMAIL = 'bachya1208@gmail.com'
 AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.6.0'
+REQUIRES_PYTHON = '>=3.5.0'
 VERSION = None
 
 # What packages are required for this module to be executed?
@@ -118,6 +118,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py35,py36
 
 [testenv]
 passenv=HOME


### PR DESCRIPTION
Make 3.5 (not 3.6) the minimum Python version.