### PR TITLE
Moved typing command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,5 @@ publish:
 	rm -rf dist/ build/ .egg regenmaschine.egg-info/
 test:
 	pipenv run py.test
+typing:
+	pipenv run mypy --ignore-missing-imports regenmaschine

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ signatures and more examples.
 4. Enter the virtual environment: `pipenv shell`
 5. Code your new feature or bug fix.
 6. Write a test that covers your new functionality.
-7. Run tests and ensure 100% code coverage: `make coverage`
-8. Add yourself to `AUTHORS.md`.
-9. Submit a pull request!
+7. Update `README.md` with any new documentation.
+8. Run tests and ensure 100% code coverage: `make coverage`
+9. Ensure you have no linting errors: `make lint`
+10. Ensure you have no typed your code correctly: `make typing`
+11. Add yourself to `AUTHORS.md`.
+12. Submit a pull request!

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ whitelist_externals = make
 deps = pipenv
 commands=
     make init
-    pipenv run mypy --ignore-missing-imports regenmaschine
+    make typing


### PR DESCRIPTION
**Describe what the PR does:**

This PR moves the type-checking command into the Makefile (for consistency).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
