### PR TITLE
Add runtime support for Python 3.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/bachya/regenmaschine/maintainability)
 [![Say Thanks](https://img.shields.io/badge/SayThanks-!-1EAEDB.svg)](https://saythanks.io/to/bachya)
 
-`regenmaschine` (German for "rain machine") is a simple, clean, well-tested Python
-library for interacting with
+`regenmaschine` (German for "rain machine") is a simple, clean, well-tested
+Python library for interacting with
 [RainMachine™ smart sprinkler controllers](http://www.rainmachine.com/).
-It gives developers an easy API to manage their
-controllers over their local LAN.
+It gives developers an easy API to manage their controllers over their local
+LAN.
 
 # PLEASE READ: Version 1.0.0 and Beyond
 
@@ -26,6 +26,17 @@ Version 1.0.0 of `regenmaschine` makes several breaking, but necessary changes:
 
 If you wish to continue using the previous, synchronous version of
 `regenmaschine`, make sure to pin version 0.4.2.
+
+# Python Versions
+
+`regenmaschine` is currently supported on:
+
+* Python 3.5
+* Python 3.6
+* Python 3.7
+
+However, running the test suite currently requires Python 3.6 or higher; tests
+run on Python 3.5 will fail.
 
 # Installation
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DESCRIPTION = 'A simple API for RainMachine sprinkler controllers'
 URL = 'https://github.com/bachya/regenmaschine'
 EMAIL = 'bachya1208@gmail.com'
 AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.6.0'
+REQUIRES_PYTHON = '>=3.5.3'
 VERSION = None
 
 # What packages are required for this module to be executed?
@@ -118,6 +118,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds runtime support for Python 3.5. Note that tests need Python 3.6+ to run.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
