### PR TITLE
Add API, hardware, and software version properties to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ async def main() -> None:
       print('Name: {0}'.format(client.name))
       print('Host: {0}'.format(client.host))
       print('MAC Address: {0}'.format(client.mac))
+      print('API Version: {0}'.format(client.api_version))
+      print('Software Version: {0}'.format(client.software_version))
+      print('Hardware Version: {0}'.format(client.hardware_version))
 
       # Get all diagnostic information:
       diagnostics = await client.diagnostics.current()

--- a/example.py
+++ b/example.py
@@ -20,6 +20,9 @@ async def main():
             print('Name: {0}'.format(client.name))
             print('Host: {0}'.format(client.host))
             print('MAC Address: {0}'.format(client.mac))
+            print('API Version: {0}'.format(client.api_version))
+            print('Software Version: {0}'.format(client.software_version))
+            print('Hardware Version: {0}'.format(client.hardware_version))
 
             # Work with diagnostics:
             print()

--- a/regenmaschine/api.py
+++ b/regenmaschine/api.py
@@ -1,0 +1,14 @@
+"""Define an object to interact with API info."""
+from typing import Awaitable, Callable
+
+
+class API:  # pylint: disable=too-few-public-methods
+    """Define a provisioning object."""
+
+    def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
+        """Initialize."""
+        self._request = request
+
+    async def versions(self) -> dict:
+        """Get software, hardware, and API versions."""
+        return await self._request('get', 'apiVer')

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -7,6 +7,7 @@ from typing import Union  # noqa
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
+from .api import API
 from .errors import RequestError, TokenExpiredError
 from .diagnostics import Diagnostics
 from .parser import Parser
@@ -32,10 +33,14 @@ class Client:
         self._port = port
         self._ssl = ssl
         self._websession = websession
+        self.api_version = None  # type: Union[None, str]
+        self.hardware_version = None  # type: Union[None, int]
         self.host = host
         self.mac = None
         self.name = None  # type: Union[None, str]
+        self.software_version = None  # type: Union[None, str]
 
+        self.api = API(self._request)
         self.diagnostics = Diagnostics(self._request)
         self.parsers = Parser(self._request)
         self.programs = Program(self._request)
@@ -95,6 +100,11 @@ class Client:
         wifi_data = await self.provisioning.wifi()
         self.mac = wifi_data['macAddress']
         self.name = await self.provisioning.device_name
+
+        version_data = await self.api.versions()
+        self.api_version = version_data['apiVer']
+        self.hardware_version = version_data['hwVer']
+        self.software_version = version_data['swVer']
 
 
 async def login(

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,9 +1,12 @@
 """Define constants used in tests."""
 TEST_ACCESS_TOKEN = '12345abcdef'
+TEST_API_VERSION = "4.5.0"
 TEST_HOST = '192.168.1.100'
+TEST_HW_VERSION = 3
 TEST_MAC = 'ab:cd:ef:12:34:56'
 TEST_NAME = 'My House'
 TEST_PASSWORD = 'the_password_123'
 TEST_PORT = 8081
+TEST_SW_VERSION = '4.0.925'
 TEST_TOTP_CODE = 123456
 TEST_URL = 'https://{0}:{1}'.format(TEST_HOST, TEST_PORT)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -5,12 +5,13 @@ import aresponses
 import pytest
 
 from ..const import TEST_ACCESS_TOKEN, TEST_HOST, TEST_PORT, TEST_TOTP_CODE
+from .api import apiver_json
 from .provision import provision_name_json, provision_wifi_json
 
 
 @pytest.fixture()
 def authenticated_client(
-        auth_login_json, event_loop, provision_name_json,
+        apiver_json, auth_login_json, event_loop, provision_name_json,
         provision_wifi_json):
     """Return an aresponses server relating to an authenticated client."""
     client = aresponses.ResponsesMockServer(loop=event_loop)
@@ -19,12 +20,13 @@ def authenticated_client(
         aresponses.Response(text=json.dumps(auth_login_json), status=200))
     client.add(
         '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision/name', 'get',
-        aresponses.Response(
-            text=json.dumps(provision_name_json), status=200))
+        aresponses.Response(text=json.dumps(provision_name_json), status=200))
     client.add(
         '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision/wifi', 'get',
-        aresponses.Response(
-            text=json.dumps(provision_wifi_json), status=200))
+        aresponses.Response(text=json.dumps(provision_wifi_json), status=200))
+    client.add(
+        '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/apiVer', 'get',
+        aresponses.Response(text=json.dumps(apiver_json), status=200))
 
     return client
 

--- a/tests/fixtures/api.py
+++ b/tests/fixtures/api.py
@@ -1,0 +1,8 @@
+"""Define fixtures related to the "api" endpoint."""
+import pytest
+
+
+@pytest.fixture()
+def apiver_json():
+    """Return a /apiVer response."""
+    return {"apiVer": "4.5.0", "hwVer": 3, "swVer": "4.0.925"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,10 +10,11 @@ from regenmaschine import login
 from regenmaschine.errors import RequestError, TokenExpiredError
 
 from .const import (
-    TEST_ACCESS_TOKEN, TEST_HOST, TEST_MAC, TEST_NAME, TEST_PASSWORD,
-    TEST_PORT)
+    TEST_ACCESS_TOKEN, TEST_API_VERSION, TEST_HOST, TEST_HW_VERSION, TEST_MAC,
+    TEST_NAME, TEST_PASSWORD, TEST_PORT, TEST_SW_VERSION)
 from .fixtures import (
     authenticated_client, auth_login_json, unauthenticated_json)
+from .fixtures.api import apiver_json
 from .fixtures.provision import provision_name_json, provision_wifi_json
 
 
@@ -30,8 +31,11 @@ async def test_authentication_success(authenticated_client, event_loop):
                 ssl=False)
 
             assert client._access_token == TEST_ACCESS_TOKEN
-            assert client.name == TEST_NAME
+            assert client.api_version == TEST_API_VERSION
+            assert client.hardware_version == TEST_HW_VERSION
             assert client.mac == TEST_MAC
+            assert client.name == TEST_NAME
+            assert client.software_version == TEST_SW_VERSION
 
 
 @pytest.mark.asyncio

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -11,6 +11,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.diagnostics import *
 from .fixtures.provision import provision_name_json, provision_wifi_json
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -9,6 +9,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PORT, TEST_PASSWORD
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.program import *
 from .fixtures.provision import provision_name_json, provision_wifi_json
 

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -9,6 +9,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.provision import *
 
 

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -9,6 +9,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.provision import provision_name_json, provision_wifi_json
 from .fixtures.restrictions import *
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -10,6 +10,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.provision import provision_name_json, provision_wifi_json
 from .fixtures.stats import *
 

--- a/tests/test_watering.py
+++ b/tests/test_watering.py
@@ -11,6 +11,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.provision import provision_name_json, provision_wifi_json
 from .fixtures.watering import *
 

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -10,6 +10,7 @@ from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
 from .fixtures import authenticated_client, auth_login_json
+from .fixtures.api import apiver_json
 from .fixtures.provision import provision_name_json, provision_wifi_json
 from .fixtures.zone import *
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds three new attributes to the `Client` object:

- `api_version`
- `hardware_version`
- `software_version`

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
