### PR TITLE
Add support for configurable request timeouts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 [dev-packages]
 "flake8" = "*"
 aresponses = "*"
+asynctest = "*"
 detox = "*"
 mypy = "*"
 pydocstyle = "*"

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,12 @@
+[MESSAGES CONTROL]
+# Reasons disabled:
+# unnecessary-pass - This can hurt readability
+disable=
+  unnecessary-pass
+
+[REPORTS]
+reports=no
+
+[FORMAT]
+expected-line-ending-format=LF
+


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/home-assistant/home-assistant/issues/19416 revealed that `regenmaschine` uses `aiohttp`'s default timeout of 5 minutes per request; this means that if the controller isn't reachable, other activities will hang for 5 minutes until the request times out. This PR adds support for a configurable timeout for all requests (default set to 10 seconds).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
