### PR TITLE
Remove aiodns requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiodns',
     'aiohttp'
 ]
 


### PR DESCRIPTION
**Describe what the PR does:**
aiodns is an optional dependency for aiohttp and it requires C compilation, which does not work on mac.
**Does this fix a specific issue?**

Fixes https://github.com/bachya/regenmaschine/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests is written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [ ] Ensure you have no linting errors: `make lint` (after running `make init`)
- [ ] Ensure you have typed your code correctly: `make typing` (after running `make init`)
- [ ] Add yourself to `AUTHORS.md`.
