### PR TITLE
Add support for watering/pauseall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 clean:
 	pipenv --rm
 coverage:
-	pipenv run py.test -s --verbose --cov-report term-missing --cov-report xml --cov=pyopenuv tests
+	pipenv run py.test -s --verbose --cov-report term-missing --cov-report xml --cov=regenmaschine tests
 init:
 	pip3 install --upgrade pip pipenv
 	pipenv lock
 	pipenv install --three --dev
 lint:
-	pipenv run flake8 pyopenuv
-	pipenv run pydocstyle pyopenuv
-	pipenv run pylint pyopenuv
+	pipenv run flake8 regenmaschine
+	pipenv run pydocstyle regenmaschine
+	pipenv run pylint regenmaschine
 publish:
 	pipenv run python setup.py sdist bdist_wheel
 	pipenv run twine upload dist/*
-	rm -rf dist/ build/ .egg pyopenuv.egg-info/
+	rm -rf dist/ build/ .egg regenmaschine.egg-info/
 test:
 	pipenv run py.test
 typing:
-	pipenv run mypy --ignore-missing-imports pyopenuv
+	pipenv run mypy --ignore-missing-imports regenmaschine

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ async def main() -> None:
       queue = await client.watering.queue()
       runs = await client.watering.runs(date=datetime.date.today())
 
+      # Pause all watering activities for 30 seconds:
+      await client.watering.pause_all(30)
+
+      # Unpause all watering activities:
+      await client.watering.unpause_all()
+
       # Stop all watering activities:
       await client.watering.stop_all()
 

--- a/example.py
+++ b/example.py
@@ -128,6 +128,16 @@ async def main():
                         watering_run['dateTime'], watering_run['et0']))
 
             print()
+            print('PAUSING ALL WATERING FOR 30 SECONDS')
+            print(await client.watering.pause_all(30))
+
+            await asyncio.sleep(3)
+
+            print()
+            print('UNPAUSING WATERING')
+            print(await client.watering.unpause_all())
+
+            print()
             print('STOPPING ALL WATERING')
             print(await client.watering.stop_all())
 

--- a/regenmaschine/watering.py
+++ b/regenmaschine/watering.py
@@ -27,6 +27,11 @@ class Watering:
         data = await self._request('get', endpoint)
         return data['waterLog']['days']
 
+    async def pause_all(self, seconds: int) -> dict:
+        """Pause all watering for a specified number of seconds."""
+        return await self._request(
+            'post', 'watering/pauseall', json={'duration': seconds})
+
     async def queue(self) -> list:
         """Return the queue of active watering activities."""
         data = await self._request('get', 'watering/queue')
@@ -46,3 +51,7 @@ class Watering:
     async def stop_all(self) -> dict:
         """Stop all programs and zones from running."""
         return await self._request('post', 'watering/stopall')
+
+    async def unpause_all(self) -> dict:
+        """Unpause all paused watering."""
+        return await self.pause_all(0)

--- a/tests/fixtures/watering.py
+++ b/tests/fixtures/watering.py
@@ -241,6 +241,12 @@ def watering_past_json():
 
 
 @pytest.fixture()
+def watering_pause_json():
+    """Return a /watering/pauseall response."""
+    return {"statusCode": 0, "message": "OK"}
+
+
+@pytest.fixture()
 def watering_queue_json():
     """Return a /watering/queue response."""
     return {"queue": []}

--- a/tests/test_watering.py
+++ b/tests/test_watering.py
@@ -19,7 +19,8 @@ from .fixtures.watering import *
 @pytest.mark.asyncio
 async def test_endpoints(
         aresponses, authenticated_client, event_loop, watering_log_json,
-        watering_past_json, watering_queue_json, watering_stopall_json):
+        watering_past_json, watering_pause_json, watering_queue_json,
+        watering_stopall_json):
     """Test all endpoints."""
     today = datetime.date.today()
     today_str = today.strftime('%Y-%m-%d')
@@ -30,6 +31,16 @@ async def test_endpoints(
             '/api/4/watering/log/details/{0}/{1}'.format(today_str, 2), 'get',
             aresponses.Response(
                 text=json.dumps(watering_log_json), status=200))
+        authenticated_client.add(
+            '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/pauseall',
+            'post',
+            aresponses.Response(
+                text=json.dumps(watering_pause_json), status=200))
+        authenticated_client.add(
+            '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/pauseall',
+            'post',
+            aresponses.Response(
+                text=json.dumps(watering_pause_json), status=200))
         authenticated_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/queue',
             'get',
@@ -57,6 +68,12 @@ async def test_endpoints(
 
             data = await client.watering.log(today, 2, details=True)
             assert len(data) == 2
+
+            data = await client.watering.pause_all(30)
+            assert data['message'] == 'OK'
+
+            data = await client.watering.unpause_all()
+            assert data['message'] == 'OK'
 
             data = await client.watering.queue()
             assert not data


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for the `watering/pauseall` endpoint.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/regenmaschine/issues/26
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)