### PR TITLE
Add ability to remove inactive programs from programs.all()

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ async def main() -> None:
       # Get all programs:
       programs = await client.programs.all():
 
+      # Include inactive programs:
+      programs = await client.programs.all(include_inactive=True):
+
       # Get a specific program:
       program_1 = await client.programs.get(1)
 

--- a/regenmaschine/program.py
+++ b/regenmaschine/program.py
@@ -14,10 +14,10 @@ class Program:
         return await self._request(
             'post', 'program/{0}'.format(program_id), json=json)
 
-    async def all(self) -> list:
+    async def all(self, include_inactive: bool = False) -> list:
         """Return all programs."""
         data = await self._request('get', 'program')
-        return data['programs']
+        return [p for p in data['programs'] if include_inactive or p['active']]
 
     async def disable(self, program_id: int) -> dict:
         """Disable a program."""

--- a/tests/fixtures/program.py
+++ b/tests/fixtures/program.py
@@ -133,7 +133,135 @@ def program_json():
                 "userPercentage": 1.0,
                 "minRuntimeCoef": 1
             }]
-        }]
+        },
+	{
+            "uid": 1,
+            "name": "Morning",
+            "active": False,
+            "startTime": "06:00",
+            "cycles": 0,
+            "soak": 0,
+            "cs_on": False,
+            "delay": 0,
+            "delay_on": False,
+            "status": 0,
+            "startTimeParams": {
+                "offsetSign": 0,
+                "type": 0,
+                "offsetMinutes": 0
+            },
+            "frequency": {
+                "type": 0,
+                "param": "0"
+            },
+            "coef": 0.0,
+            "ignoreInternetWeather": False,
+            "futureField1": 0,
+            "freq_modified": 0,
+            "useWaterSense": False,
+            "nextRun": "2018-06-04",
+            "startDate": "2018-04-28",
+            "endDate": None,
+            "yearlyRecurring": True,
+            "simulationExpired": False,
+            "wateringTimes": [{
+                "id": 1,
+                "order": -1,
+                "name": "Landscaping",
+                "duration": 0,
+                "active": True,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 2,
+                "order": -1,
+                "name": "Flower Box",
+                "duration": 0,
+                "active": True,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 3,
+                "order": -1,
+                "name": "TEST",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 4,
+                "order": -1,
+                "name": "Zone 4",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 5,
+                "order": -1,
+                "name": "Zone 5",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 6,
+                "order": -1,
+                "name": "Zone 6",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 7,
+                "order": -1,
+                "name": "Zone 7",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 8,
+                "order": -1,
+                "name": "Zone 8",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 9,
+                "order": -1,
+                "name": "Zone 9",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 10,
+                "order": -1,
+                "name": "Zone 10",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 11,
+                "order": -1,
+                "name": "Zone 11",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }, {
+                "id": 12,
+                "order": -1,
+                "name": "Zone 12",
+                "duration": 0,
+                "active": False,
+                "userPercentage": 1.0,
+                "minRuntimeCoef": 1
+            }]
+	}]
     }
 
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -60,6 +60,28 @@ async def test_program_get(
                 port=TEST_PORT,
                 ssl=False)
 
+            data = await client.programs.all(include_inactive=True)
+            assert len(data) == 2
+            assert data[0]['name'] == 'Morning'
+
+
+@pytest.mark.asyncio
+async def test_program_get_active(
+        aresponses, authenticated_client, event_loop, program_json):
+    """Test getting only active programs."""
+    async with authenticated_client:
+        authenticated_client.add(
+            '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program', 'get',
+            aresponses.Response(text=json.dumps(program_json), status=200))
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = await login(
+                TEST_HOST,
+                TEST_PASSWORD,
+                websession,
+                port=TEST_PORT,
+                ssl=False)
+
             data = await client.programs.all()
             assert len(data) == 1
             assert data[0]['name'] == 'Morning'


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the ability to ignore inactive programs in `programs.all()` (similar to the existing functionality in `zones.all()`).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
