### PR TITLE
Copy API argument optionality to Client.from_local

### DIFF
--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -20,6 +20,7 @@ from .stats import Stats
 from .watering import Watering
 from .zone import Zone
 
+DEFAULT_LOCAL_PORT = 8080
 DEFAULT_TIMEOUT = 10
 
 
@@ -53,8 +54,13 @@ class Client:
 
     @classmethod
     async def create_local(  # pylint: disable=too-many-arguments
-            cls, host: str, password: str, websession: ClientSession, port,
-            ssl, request_timeout) -> 'Client':
+            cls,
+            host: str,
+            password: str,
+            websession: ClientSession,
+            port: int = DEFAULT_LOCAL_PORT,
+            ssl: bool = True,
+            request_timeout: int = DEFAULT_TIMEOUT) -> 'Client':
         """Create a local client."""
         klass = cls(websession, request_timeout)
         klass._url_base = 'https://{0}:{1}/api/4'.format(host, port)

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-many-instance-attributes
 import asyncio
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional  # pylint: disable=unused-import
 
 import async_timeout
 from aiohttp import ClientSession


### PR DESCRIPTION
**Describe what the PR does:**

Following up to https://github.com/bachya/regenmaschine/pull/35, this PR alters `regenmaschine.Client.from_local`'s API to exactly mimic `regenmaschine.Client.login`'s (which will make eventual, full deprecation easier).

**Does this fix a specific issue?**

Addresses part of #34.
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
