### PR TITLE
Add concept of Controller

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,8 +1,10 @@
 [MESSAGES CONTROL]
 # Reasons disabled:
 # unnecessary-pass - This can hurt readability
+# unused-import - Typing imports often get caught
 disable=
-  unnecessary-pass
+  unnecessary-pass,
+  unused-import
 
 [REPORTS]
 reports=no

--- a/regenmaschine/api.py
+++ b/regenmaschine/api.py
@@ -3,7 +3,7 @@ from typing import Awaitable, Callable
 
 
 class API:  # pylint: disable=too-few-public-methods
-    """Define a provisioning object."""
+    """Define an API object."""
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -1,103 +1,57 @@
 """Define a client to interact with a RainMachine unit."""
-# pylint: disable=protected-access,too-few-public-methods
-# pylint: disable=too-many-instance-attributes
 import asyncio
-from datetime import datetime, timedelta
-from typing import Optional  # pylint: disable=unused-import
+from datetime import datetime
+from typing import Dict
 
 import async_timeout
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
-from regenmaschine.api import API
+from regenmaschine.controller import Controller, LocalController
 from regenmaschine.errors import RequestError, TokenExpiredError
-from regenmaschine.diagnostics import Diagnostics
-from regenmaschine.parser import Parser
-from regenmaschine.program import Program
-from regenmaschine.provision import Provision
-from regenmaschine.restriction import Restriction
-from regenmaschine.stats import Stats
-from regenmaschine.watering import Watering
-from regenmaschine.zone import Zone
 
 DEFAULT_LOCAL_PORT = 8080
 DEFAULT_TIMEOUT = 10
 
 
-class Client:
+class Client:  # pylint: disable=too-few-public-methods
     """Define the client."""
 
     def __init__(
-            self, websession: ClientSession, request_timeout: int) -> None:
+            self,
+            websession: ClientSession,
+            request_timeout: int = DEFAULT_TIMEOUT) -> None:
         """Initialize."""
-        self._access_token = None
-        self._access_token_expiration = None  # type: Optional[datetime]
-        self._request_timeout = request_timeout
-        self._ssl = True
-        self._url_base = None  # type: Optional[str]
         self._websession = websession
-        self.api_version = None  # type: Optional[str]
-        self.hardware_version = None  # type: Optional[int]
-        self.mac = None
-        self.name = None  # type: Optional[str]
-        self.software_version = None  # type: Optional[str]
+        self.controllers = {}  # type: Dict[str, Controller]
+        self.request_timeout = request_timeout
 
-        self.api = API(self._request)
-        self.diagnostics = Diagnostics(self._request)
-        self.parsers = Parser(self._request)
-        self.programs = Program(self._request)
-        self.provisioning = Provision(self._request)
-        self.restrictions = Restriction(self._request)
-        self.stats = Stats(self._request)
-        self.watering = Watering(self._request)
-        self.zones = Zone(self._request)
-
-    @classmethod
-    async def create_local(  # pylint: disable=too-many-arguments
-            cls,
+    async def load_local(  # pylint: disable=too-many-arguments
+            self,
             host: str,
             password: str,
-            websession: ClientSession,
             port: int = DEFAULT_LOCAL_PORT,
-            ssl: bool = True,
-            request_timeout: int = DEFAULT_TIMEOUT) -> 'Client':
+            ssl: bool = True) -> None:
         """Create a local client."""
-        klass = cls(websession, request_timeout)
-        klass._url_base = 'https://{0}:{1}/api/4'.format(host, port)
-        klass._ssl = ssl
-
-        auth_resp = await klass._request(
-            'post', 'auth/login', json={
-                'pwd': password,
-                'remember': 1
-            })
-        klass._access_token = auth_resp['access_token']
-        klass._access_token_expiration = (
-            datetime.now() +
-            timedelta(seconds=int(auth_resp['expires_in']) - 10))
-
-        wifi_data = await klass.provisioning.wifi()
-        klass.mac = wifi_data['macAddress']
-        klass.name = await klass.provisioning.device_name
-
-        version_data = await klass.api.versions()
-        klass.api_version = version_data['apiVer']
-        klass.hardware_version = version_data['hwVer']
-        klass.software_version = version_data['swVer']
-
-        return klass
+        controller = LocalController(
+            self._request, host, port, ssl, self._websession)
+        await controller.login(password)
+        self.controllers[controller.mac] = controller  # type: ignore
 
     async def _request(
             self,
             method: str,
-            endpoint: str,
+            url: str,
             *,
+            access_token: str = None,
+            access_token_expiration: datetime = None,
             headers: dict = None,
             params: dict = None,
-            json: dict = None) -> dict:
+            json: dict = None,
+            ssl: bool = True) -> dict:
         """Make a request against the RainMachine device."""
-        if (self._access_token_expiration
-                and datetime.now() >= self._access_token_expiration):
+        if (access_token_expiration
+                and datetime.now() >= access_token_expiration):
             raise TokenExpiredError('Long-lived access token has expired')
 
         if not headers:
@@ -106,16 +60,14 @@ class Client:
 
         if not params:
             params = {}
-        if self._access_token:
-            params.update({'access_token': self._access_token})
-
-        url = '{0}/{1}'.format(self._url_base, endpoint)
+        if access_token:
+            params.update({'access_token': access_token})
 
         try:
-            async with async_timeout.timeout(self._request_timeout):
+            async with async_timeout.timeout(self.request_timeout):
                 async with self._websession.request(
                         method, url, headers=headers, params=params, json=json,
-                        ssl=self._ssl) as resp:
+                        ssl=ssl) as resp:
                     resp.raise_for_status()
                     data = await resp.json(content_type=None)
         except ClientError as err:
@@ -134,9 +86,9 @@ async def login(
         *,
         port: int = 8080,
         ssl: bool = True,
-        request_timeout: int = DEFAULT_TIMEOUT) -> Client:
+        request_timeout: int = DEFAULT_TIMEOUT) -> Controller:
     """Authenticate against a RainMachine device."""
     print('regenmaschine.client.login() is deprecated; see documentation!')
-    client = await Client.create_local(
-        host, password, websession, port, ssl, request_timeout)
-    return client
+    client = Client(websession, request_timeout)
+    await client.load_local(host, password, port, ssl)
+    return next(iter(client.controllers.values()))

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -1,13 +1,103 @@
 """Define a RainMachine controller class."""
-from typing import TYPE_CHECKING
+# pylint: disable=too-few-public-methods,too-many-instance-attributes
+# pylint: disable=unused-import
+from datetime import datetime, timedelta
+from typing import Awaitable, Callable, Optional
 
-if TYPE_CHECKING:
-    from regenmaschine.client import Client
+from aiohttp import ClientSession
+
+from regenmaschine.api import API
+from regenmaschine.diagnostics import Diagnostics
+from regenmaschine.parser import Parser
+from regenmaschine.program import Program
+from regenmaschine.provision import Provision
+from regenmaschine.restriction import Restriction
+from regenmaschine.stats import Stats
+from regenmaschine.watering import Watering
+from regenmaschine.zone import Zone
+
+URL_BASE_LOCAL = 'https://{0}:{1}/api/4'
 
 
 class Controller:
     """Define the controller."""
 
-    def __init__(self, client: Client) -> None:
+    def __init__(  # pylint: disable=too-many-arguments
+            self, request: Callable[..., Awaitable[dict]], host: str,
+            port: int, ssl: bool, websession: ClientSession) -> None:
         """Initialize."""
-        self._client = client
+        self._access_token = None  # type: Optional[str]
+        self._access_token_expiration = None  # type: Optional[datetime]
+        self._client_request = request
+        self._port = port
+        self._ssl = ssl
+        self._websession = websession
+        self.api_version = None  # type: Optional[str]
+        self.hardware_version = None  # type: Optional[int]
+        self.host = host
+        self.mac = None
+        self.name = None  # type: Optional[str]
+        self.software_version = None  # type: Optional[str]
+
+        # API endpoints:
+        self.api = API(self._request)
+        self.diagnostics = Diagnostics(self._request)
+        self.parsers = Parser(self._request)
+        self.programs = Program(self._request)
+        self.provisioning = Provision(self._request)
+        self.restrictions = Restriction(self._request)
+        self.stats = Stats(self._request)
+        self.watering = Watering(self._request)
+        self.zones = Zone(self._request)
+
+    async def _request(
+            self,
+            method: str,
+            endpoint: str,
+            *,
+            headers: dict = None,
+            params: dict = None,
+            json: dict = None,
+            ssl: bool = True) -> dict:
+        """Wrap the generic request method to add access token, etc."""
+        return await self._client_request(
+            method,
+            '{0}/{1}'.format(
+                URL_BASE_LOCAL.format(self.host, self._port), endpoint),
+            access_token=self._access_token,
+            access_token_expiration=self._access_token_expiration,
+            headers=headers,
+            params=params,
+            json=json,
+            ssl=ssl)
+
+    async def _save_device_info(self):
+        """Save various device properties."""
+        wifi_data = await self.provisioning.wifi()
+        self.mac = wifi_data['macAddress']
+        self.name = await self.provisioning.device_name
+
+        version_data = await self.api.versions()
+        self.api_version = version_data['apiVer']
+        self.hardware_version = version_data['hwVer']
+        self.software_version = version_data['swVer']
+
+
+class LocalController(Controller):  # pylint: disable=too-few-public-methods
+    """Define a controller accessed over the LAN."""
+
+    async def login(self, password):
+        """Perform post-creation initialization of the object."""
+        auth_resp = await self._client_request(
+            'post',
+            'https://{0}:{1}/api/4/auth/login'.format(self.host, self._port),
+            json={
+                'pwd': password,
+                'remember': 1
+            })
+
+        self._access_token = auth_resp['access_token']
+        self._access_token_expiration = datetime.now() + timedelta(
+            seconds=int(auth_resp['expires_in']) - 10)
+
+        await self._save_device_info()

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -1,0 +1,13 @@
+"""Define a RainMachine controller class."""
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from regenmaschine.client import Client
+
+
+class Controller:
+    """Define the controller."""
+
+    def __init__(self, client: Client) -> None:
+        """Initialize."""
+        self._client = client

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -1,6 +1,5 @@
 """Define a RainMachine controller class."""
 # pylint: disable=too-few-public-methods,too-many-instance-attributes
-# pylint: disable=unused-import
 from datetime import datetime, timedelta
 from typing import Awaitable, Callable, Optional
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the concept of a `controller` object, which is separate from the `client` (the `client` can contain many `controllers`). This helps to pave the way for remote access.

No breaking changes to original API thus far...

**Does this fix a specific issue?**

Addresses part of #34.
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)