### PR TITLE
Add remote controller

### DIFF
--- a/example.py
+++ b/example.py
@@ -19,7 +19,6 @@ async def main():
 
             print('CLIENT INFORMATION')
             print('Name: {0}'.format(client.name))
-            print('Host: {0}'.format(client.host))
             print('MAC Address: {0}'.format(client.mac))
             print('API Version: {0}'.format(client.api_version))
             print('Software Version: {0}'.format(client.software_version))

--- a/regenmaschine/__init__.py
+++ b/regenmaschine/__init__.py
@@ -1,2 +1,2 @@
 """Initialize."""
-from .client import login  # noqa
+from .client import Client, login  # noqa

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -127,8 +127,7 @@ class Client:  # pylint: disable=too-few-public-methods
                         ssl=ssl) as resp:
                     resp.raise_for_status()
                     data = await resp.json(content_type=None)
-                    if data.get('errorType') or data.get('error'):
-                        _raise_for_remote_status(url, data)
+                    _raise_for_remote_status(url, data)
         except ClientError as err:
             raise RequestError(
                 'Error requesting data from {0}: {1}'.format(url, err))
@@ -140,15 +139,13 @@ class Client:  # pylint: disable=too-few-public-methods
 
 def _raise_for_remote_status(url: str, data: dict) -> None:
     """Raise an error from the remote API if necessary."""
-    if data.get('errorType') and data['errorType'] <= 0:
-        return
+    if data.get('errorType') and data['errorType'] > 0:
+        raise_remote_error(data['errorType'])
 
     if data.get('statusCode') and data['statusCode'] != 200:
         raise RequestError(
             'Error requesting data from {0}: {1} {2}'.format(
                 url, data['statusCode'], data['message']))
-
-    raise_remote_error(data['errorType'])
 
 
 async def login(

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -16,24 +16,24 @@ from regenmaschine.watering import Watering
 from regenmaschine.zone import Zone
 
 URL_BASE_LOCAL = 'https://{0}:{1}/api/4'
+URL_BASE_REMOTE = 'https://api.rainmachine.com/{0}/api/4'
 
 
-class Controller:
+class Controller:  # pylint: disable=too-many-instance-attributes
     """Define the controller."""
 
-    def __init__(  # pylint: disable=too-many-arguments
-            self, request: Callable[..., Awaitable[dict]], host: str,
-            port: int, ssl: bool, websession: ClientSession) -> None:
+    def __init__(
+            self, request: Callable[..., Awaitable[dict]],
+            websession: ClientSession) -> None:
         """Initialize."""
         self._access_token = None  # type: Optional[str]
         self._access_token_expiration = None  # type: Optional[datetime]
         self._client_request = request
-        self._port = port
-        self._ssl = ssl
+        self._host = None  # type: Optional[str]
+        self._ssl = True
         self._websession = websession
         self.api_version = None  # type: Optional[str]
         self.hardware_version = None  # type: Optional[int]
-        self.host = host
         self.mac = None
         self.name = None  # type: Optional[str]
         self.software_version = None  # type: Optional[str]
@@ -61,8 +61,7 @@ class Controller:
         """Wrap the generic request method to add access token, etc."""
         return await self._client_request(
             method,
-            '{0}/{1}'.format(
-                URL_BASE_LOCAL.format(self.host, self._port), endpoint),
+            '{0}/{1}'.format(self._host, endpoint),
             access_token=self._access_token,
             access_token_expiration=self._access_token_expiration,
             headers=headers,
@@ -70,26 +69,24 @@ class Controller:
             json=json,
             ssl=ssl)
 
-    async def _save_device_info(self):
-        """Save various device properties."""
-        wifi_data = await self.provisioning.wifi()
-        self.mac = wifi_data['macAddress']
-        self.name = await self.provisioning.device_name
 
-        version_data = await self.api.versions()
-        self.api_version = version_data['apiVer']
-        self.hardware_version = version_data['hwVer']
-        self.software_version = version_data['swVer']
-
-
-class LocalController(Controller):  # pylint: disable=too-few-public-methods
+class LocalController(Controller):
     """Define a controller accessed over the LAN."""
 
+    def __init__(  # pylint: disable=too-many-arguments
+            self, request: Callable[..., Awaitable[dict]], host: str,
+            port: int, ssl: bool, websession: ClientSession) -> None:
+        """Initialize."""
+        super().__init__(request, websession)
+
+        self._host = URL_BASE_LOCAL.format(host, port)
+        self._ssl = ssl
+
     async def login(self, password):
-        """Perform post-creation initialization of the object."""
+        """Authenticate against the device (locally)."""
         auth_resp = await self._client_request(
             'post',
-            'https://{0}:{1}/api/4/auth/login'.format(self.host, self._port),
+            '{0}/auth/login'.format(self._host),
             json={
                 'pwd': password,
                 'remember': 1
@@ -99,4 +96,22 @@ class LocalController(Controller):  # pylint: disable=too-few-public-methods
         self._access_token_expiration = datetime.now() + timedelta(
             seconds=int(auth_resp['expires_in']) - 10)
 
-        await self._save_device_info()
+
+class RemoteController(Controller):
+    """Define a controller accessed over RainMachine's cloud."""
+
+    async def login(
+            self, stage_1_access_token: str, sprinkler_id: str,
+            password: str) -> None:
+        """Authenticate against the device (remotely)."""
+        auth_resp = await self._client_request(
+            'post',
+            'https://my.rainmachine.com/devices/login-sprinkler',
+            access_token=stage_1_access_token,
+            json={
+                'sprinklerId': sprinkler_id,
+                'pwd': password,
+            })
+
+        self._access_token = auth_resp['access_token']
+        self._host = URL_BASE_REMOTE.format(sprinkler_id)

--- a/regenmaschine/errors.py
+++ b/regenmaschine/errors.py
@@ -17,3 +17,18 @@ class TokenExpiredError(RainMachineError):
     """Define an error for expired access tokens that can't be refreshed."""
 
     pass
+
+
+ERROR_CODES = {
+    1: 'The email has not been validated',
+}
+
+
+def raise_remote_error(error_code: int) -> None:
+    """Raise the appropriate error with a remote error code."""
+    try:
+        error = next((v for k, v in ERROR_CODES.items() if k == error_code))
+        raise RequestError(error)
+    except StopIteration:
+        raise RequestError(
+            'Unknown remote error code returned: {0}'.format(error_code))

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,12 +1,14 @@
 """Define constants used in tests."""
 TEST_ACCESS_TOKEN = '12345abcdef'
 TEST_API_VERSION = "4.5.0"
+TEST_EMAIL = 'user@host.com'
 TEST_HOST = '192.168.1.100'
 TEST_HW_VERSION = 3
 TEST_MAC = 'ab:cd:ef:12:34:56'
 TEST_NAME = 'My House'
 TEST_PASSWORD = 'the_password_123'
 TEST_PORT = 8081
+TEST_SPRINKLER_ID = '12345abcde'
 TEST_SW_VERSION = '4.0.925'
 TEST_TOTP_CODE = 123456
 TEST_URL = 'https://{0}:{1}'.format(TEST_HOST, TEST_PORT)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -4,7 +4,9 @@ import json
 import aresponses
 import pytest
 
-from ..const import TEST_ACCESS_TOKEN, TEST_HOST, TEST_PORT, TEST_TOTP_CODE
+from ..const import (
+    TEST_ACCESS_TOKEN, TEST_HOST, TEST_MAC, TEST_NAME, TEST_PORT,
+    TEST_SPRINKLER_ID, TEST_TOTP_CODE)
 from .api import apiver_json
 from .provision import provision_name_json, provision_wifi_json
 
@@ -47,6 +49,43 @@ def auth_login_json():
 def auth_totp_json():
     """Return a /auth/totp response."""
     return {"totp": TEST_TOTP_CODE}
+
+
+@pytest.fixture()
+def remote_auth_login_1_json():
+    """Return a /login/auth (remote) response."""
+    return {
+        "access_token": TEST_ACCESS_TOKEN,
+        "errorType": -1,
+    }
+
+
+@pytest.fixture()
+def remote_auth_login_2_json():
+    """Return a /devices/login-sprinkler (remote) response."""
+    return {
+        "access_token": TEST_ACCESS_TOKEN,
+        "errorType": 0,
+        "sprinklerId": TEST_SPRINKLER_ID,
+    }
+
+
+@pytest.fixture()
+def remote_sprinlers_json():
+    """Return a /devices/get-sprinklers (remote) response."""
+    return {
+        "errorType":
+            0,
+        "sprinklers": [{
+            "sprinklerId": TEST_SPRINKLER_ID,
+            "sprinklerUrl":
+                "https://api.rainmachine.com/{0}/".format(TEST_SPRINKLER_ID),
+            "mac": TEST_MAC,
+            "name": TEST_NAME,
+            "type": "SPK3",
+            "swVer": "4.0.974"
+        }]
+    }
 
 
 @pytest.fixture()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,17 +10,17 @@ import pytest
 from regenmaschine import login
 
 from .const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from .fixtures import authenticated_client, auth_login_json
+from .fixtures import authenticated_local_client, auth_login_json
 from .fixtures.api import apiver_json
 from .fixtures.provision import provision_name_json, provision_wifi_json
 
 
 @pytest.mark.asyncio
 async def test_api_versions(
-        apiver_json, aresponses, authenticated_client, event_loop):
+        apiver_json, aresponses, authenticated_local_client, event_loop):
     """Test getting API, hardware, and software versions."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/apiVer', 'get',
             aresponses.Response(text=json.dumps(apiver_json), status=200))
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,12 +8,13 @@ import aiohttp
 import asynctest
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client, login
 from regenmaschine.errors import RequestError, TokenExpiredError
 
 from tests.const import (
-    TEST_ACCESS_TOKEN, TEST_API_VERSION, TEST_HOST, TEST_HW_VERSION, TEST_MAC,
-    TEST_NAME, TEST_PASSWORD, TEST_PORT, TEST_SW_VERSION)
+    TEST_ACCESS_TOKEN, TEST_API_VERSION, TEST_EMAIL, TEST_HOST,
+    TEST_HW_VERSION, TEST_MAC, TEST_NAME, TEST_PASSWORD, TEST_PORT,
+    TEST_SW_VERSION)
 from tests.fixtures import (
     authenticated_client, auth_login_json, unauthenticated_json)
 from tests.fixtures.api import apiver_json
@@ -21,8 +22,8 @@ from tests.fixtures.provision import provision_name_json, provision_wifi_json
 
 
 @pytest.mark.asyncio
-async def test_authentication_success(authenticated_client, event_loop):
-    """Test successfully retrieving a long-lived access token."""
+async def test_legacy_login(authenticated_client, event_loop):
+    """Test loading a local client through the legacy method."""
     async with authenticated_client:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = await login(
@@ -41,26 +42,83 @@ async def test_authentication_success(authenticated_client, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_authentication_failure(
+async def test_load_local(authenticated_client, event_loop):
+    """Test loading a local client."""
+    async with authenticated_client:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
+
+            assert len(client.controllers) == 1
+
+            controller = client.controllers[TEST_MAC]
+            assert controller._access_token == TEST_ACCESS_TOKEN
+            assert controller.api_version == TEST_API_VERSION
+            assert controller.hardware_version == TEST_HW_VERSION
+            assert controller.mac == TEST_MAC
+            assert controller.name == TEST_NAME
+            assert controller.software_version == TEST_SW_VERSION
+
+
+@pytest.mark.asyncio
+async def test_load_local_skip(
+        aresponses, auth_login_json, provision_wifi_json, authenticated_client,
+        event_loop):
+    """Test skipping the loading of a local client if it's already loaded."""
+    authenticated_client.add(
+        '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/auth/login', 'post',
+        aresponses.Response(text=json.dumps(auth_login_json), status=200))
+    authenticated_client.add(
+        '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision/wifi', 'get',
+        aresponses.Response(text=json.dumps(provision_wifi_json), status=200))
+
+    async with authenticated_client:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
+            controller = client.controllers[TEST_MAC]
+
+            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
+            assert len(client.controllers) == 1
+            assert client.controllers[TEST_MAC] == controller
+
+
+@pytest.mark.asyncio
+async def test_load_local_failure(
         aresponses, unauthenticated_json, event_loop):
-    """Test authenticating the device."""
+    """Test loading a local client and receiving some sort of fail response."""
     aresponses.add(
         '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/auth/login', 'post',
         aresponses.Response(text=json.dumps(unauthenticated_json), status=401))
 
     with pytest.raises(RequestError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
-            await login(
-                TEST_HOST,
-                TEST_PASSWORD,
-                websession,
-                port=TEST_PORT,
-                ssl=False)
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
+
+@pytest.mark.asyncio
+async def test_load_remote(authenticated_client, event_loop):
+    """Test loading a remote client."""
+    async with authenticated_client:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD)
+
+            assert len(client.controllers) == 1
+
+            controller = client.controllers[TEST_MAC]
+            assert controller._access_token == TEST_ACCESS_TOKEN
+            assert controller.api_version == TEST_API_VERSION
+            assert controller.hardware_version == TEST_HW_VERSION
+            assert controller.mac == TEST_MAC
+            assert controller.name == TEST_NAME
+            assert controller.software_version == TEST_SW_VERSION
+
 
 
 @pytest.mark.asyncio
 async def test_token_expired_exception(authenticated_client, event_loop):
-    """Test authenticating the device."""
+    """Test that the appropriate error is thrown when a token expires."""
     async with authenticated_client:
         with pytest.raises(TokenExpiredError):
             async with aiohttp.ClientSession(loop=event_loop) as websession:
@@ -87,8 +145,8 @@ async def test_request_timeout(authenticated_client, event_loop, mocker):
     mock_login = mocker.patch('regenmaschine.login')
     mock_login.return_value = long_running_login
 
-    with asynctest.mock.patch.object(aiohttp.ClientResponse,
-                                     'json', long_running_login):
+    with asynctest.mock.patch.object(aiohttp.ClientResponse, 'json',
+                                     long_running_login):
         async with authenticated_client:
             async with aiohttp.ClientSession(loop=event_loop) as websession:
                 with pytest.raises(RequestError):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,15 +16,18 @@ from tests.const import (
     TEST_HW_VERSION, TEST_MAC, TEST_NAME, TEST_PASSWORD, TEST_PORT,
     TEST_SW_VERSION)
 from tests.fixtures import (
-    authenticated_client, auth_login_json, unauthenticated_json)
+    authenticated_local_client, authenticated_remote_client, auth_login_json,
+    remote_auth_login_1_json, remote_auth_login_2_json, remote_error_known,
+    remote_error_http_body, remote_error_unknown, remote_sprinklers_json,
+    unauthenticated_json)
 from tests.fixtures.api import apiver_json
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
 
 
 @pytest.mark.asyncio
-async def test_legacy_login(authenticated_client, event_loop):
+async def test_legacy_login(authenticated_local_client, event_loop):
     """Test loading a local client through the legacy method."""
-    async with authenticated_client:
+    async with authenticated_local_client:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = await login(
                 TEST_HOST,
@@ -42,9 +45,9 @@ async def test_legacy_login(authenticated_client, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_load_local(authenticated_client, event_loop):
+async def test_load_local(authenticated_local_client, event_loop):
     """Test loading a local client."""
-    async with authenticated_client:
+    async with authenticated_local_client:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = Client(websession)
             await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
@@ -62,23 +65,23 @@ async def test_load_local(authenticated_client, event_loop):
 
 @pytest.mark.asyncio
 async def test_load_local_skip(
-        aresponses, auth_login_json, provision_wifi_json, authenticated_client,
-        event_loop):
+        aresponses, auth_login_json, provision_wifi_json,
+        authenticated_local_client, event_loop):
     """Test skipping the loading of a local client if it's already loaded."""
-    authenticated_client.add(
+    authenticated_local_client.add(
         '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/auth/login', 'post',
         aresponses.Response(text=json.dumps(auth_login_json), status=200))
-    authenticated_client.add(
+    authenticated_local_client.add(
         '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision/wifi', 'get',
         aresponses.Response(text=json.dumps(provision_wifi_json), status=200))
 
-    async with authenticated_client:
+    async with authenticated_local_client:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = Client(websession)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, True)
             controller = client.controllers[TEST_MAC]
 
-            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, True)
             assert len(client.controllers) == 1
             assert client.controllers[TEST_MAC] == controller
 
@@ -86,7 +89,7 @@ async def test_load_local_skip(
 @pytest.mark.asyncio
 async def test_load_local_failure(
         aresponses, unauthenticated_json, event_loop):
-    """Test loading a local client and receiving some sort of fail response."""
+    """Test loading a local client and receiving a fail response."""
     aresponses.add(
         '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/auth/login', 'post',
         aresponses.Response(text=json.dumps(unauthenticated_json), status=401))
@@ -96,10 +99,11 @@ async def test_load_local_failure(
             client = Client(websession)
             await client.load_local(TEST_HOST, TEST_PASSWORD, TEST_PORT, False)
 
+
 @pytest.mark.asyncio
-async def test_load_remote(authenticated_client, event_loop):
+async def test_load_remote(authenticated_remote_client, event_loop):
     """Test loading a remote client."""
-    async with authenticated_client:
+    async with authenticated_remote_client:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = Client(websession)
             await client.load_remote(TEST_EMAIL, TEST_PASSWORD)
@@ -115,11 +119,116 @@ async def test_load_remote(authenticated_client, event_loop):
             assert controller.software_version == TEST_SW_VERSION
 
 
+@pytest.mark.asyncio
+async def test_load_remote_skip(
+        aresponses, authenticated_remote_client, remote_auth_login_1_json,
+        remote_sprinklers_json, event_loop):
+    """Test skipping the loading of a remote client if it's already loaded."""
+    authenticated_remote_client.add(
+        'my.rainmachine.com', '/login/auth', 'post',
+        aresponses.Response(
+            text=json.dumps(remote_auth_login_1_json), status=200))
+    authenticated_remote_client.add(
+        'my.rainmachine.com', '/devices/get-sprinklers', 'post',
+        aresponses.Response(
+            text=json.dumps(remote_sprinklers_json), status=200))
+
+    async with authenticated_remote_client:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD, True)
+            controller = client.controllers[TEST_MAC]
+
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD, True)
+            assert len(client.controllers) == 1
+            assert client.controllers[TEST_MAC] == controller
+
 
 @pytest.mark.asyncio
-async def test_token_expired_exception(authenticated_client, event_loop):
+async def test_load_remote_failure(
+        aresponses, unauthenticated_json, event_loop):
+    """Test loading a remote client and receiving a fail response."""
+    aresponses.add(
+        'my.rainmachine.com', '/login/auth', 'post',
+        aresponses.Response(text=json.dumps(unauthenticated_json), status=401))
+
+    with pytest.raises(RequestError):
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD)
+
+
+@pytest.mark.asyncio
+async def test_remote_error_known(aresponses, event_loop, remote_error_known):
+    """Test that remote error handling works."""
+    aresponses.add(
+        'my.rainmachine.com', '/login/auth', 'post',
+        aresponses.Response(text=json.dumps(remote_error_known), status=200))
+
+    with pytest.raises(RequestError):
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD)
+
+
+@pytest.mark.asyncio
+async def test_remote_error_http_body(
+        aresponses, event_loop, remote_error_http_body):
+    """Test that remote error handling works."""
+    aresponses.add(
+        'my.rainmachine.com', '/login/auth', 'post',
+        aresponses.Response(
+            text=json.dumps(remote_error_http_body), status=200))
+
+    with pytest.raises(RequestError):
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD)
+
+
+@pytest.mark.asyncio
+async def test_remote_error_unknown(
+        aresponses, event_loop, remote_error_unknown):
+    """Test that remote error handling works."""
+    aresponses.add(
+        'my.rainmachine.com', '/login/auth', 'post',
+        aresponses.Response(text=json.dumps(remote_error_unknown), status=200))
+
+    with pytest.raises(RequestError):
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(websession)
+            await client.load_remote(TEST_EMAIL, TEST_PASSWORD)
+
+
+@pytest.mark.asyncio
+async def test_request_timeout(authenticated_local_client, event_loop, mocker):
+    """Test whether the client properly raises an error on timeout."""
+
+    async def long_running_login(*args, **kwargs):
+        """Define a method that takes 0.5 seconds to execute."""
+        await asyncio.sleep(0.5)
+
+    mock_login = mocker.patch('regenmaschine.login')
+    mock_login.return_value = long_running_login
+
+    with asynctest.mock.patch.object(aiohttp.ClientResponse, 'json',
+                                     long_running_login):
+        async with authenticated_local_client:
+            async with aiohttp.ClientSession(loop=event_loop) as websession:
+                with pytest.raises(RequestError):
+                    await login(
+                        TEST_HOST,
+                        TEST_PASSWORD,
+                        websession,
+                        port=TEST_PORT,
+                        ssl=False,
+                        request_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_token_expired_exception(authenticated_local_client, event_loop):
     """Test that the appropriate error is thrown when a token expires."""
-    async with authenticated_client:
+    async with authenticated_local_client:
         with pytest.raises(TokenExpiredError):
             async with aiohttp.ClientSession(loop=event_loop) as websession:
                 client = await login(
@@ -132,28 +241,3 @@ async def test_token_expired_exception(authenticated_client, event_loop):
                 client._access_token_expiration = datetime.now() - timedelta(
                     hours=1)
                 await client._request('get', 'random/endpoint')
-
-
-@pytest.mark.asyncio
-async def test_request_timeout(authenticated_client, event_loop, mocker):
-    """Test whether the client properly raises an error on timeout."""
-
-    async def long_running_login(*args, **kwargs):
-        """Define a method that takes 0.5 seconds to execute."""
-        await asyncio.sleep(0.5)
-
-    mock_login = mocker.patch('regenmaschine.login')
-    mock_login.return_value = long_running_login
-
-    with asynctest.mock.patch.object(aiohttp.ClientResponse, 'json',
-                                     long_running_login):
-        async with authenticated_client:
-            async with aiohttp.ClientSession(loop=event_loop) as websession:
-                with pytest.raises(RequestError):
-                    await login(
-                        TEST_HOST,
-                        TEST_PASSWORD,
-                        websession,
-                        port=TEST_PORT,
-                        ssl=False,
-                        request_timeout=0.1)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -10,7 +10,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.diagnostics import *
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
@@ -18,10 +18,10 @@ from tests.fixtures.provision import provision_name_json, provision_wifi_json
 
 @pytest.mark.asyncio
 async def test_diagnostics_current(
-        aresponses, authenticated_client, diag_json, event_loop):
+        aresponses, authenticated_local_client, diag_json, event_loop):
     """Test retrieving current diagnostics."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/diag', 'get',
             aresponses.Response(text=json.dumps(diag_json), status=200))
 
@@ -39,10 +39,10 @@ async def test_diagnostics_current(
 
 @pytest.mark.asyncio
 async def test_diagnostics_log(
-        aresponses, authenticated_client, diag_log_json, event_loop):
+        aresponses, authenticated_local_client, diag_log_json, event_loop):
     """Test retrieving the entire diagnostics log."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/diag/log', 'get',
             aresponses.Response(text=json.dumps(diag_log_json), status=200))
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_ACCESS_TOKEN, TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.parser import *
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
@@ -16,10 +16,10 @@ from tests.fixtures.provision import provision_name_json, provision_wifi_json
 
 @pytest.mark.asyncio
 async def test_parsers_current(
-        aresponses, authenticated_client, event_loop, parser_json):
+        aresponses, authenticated_local_client, event_loop, parser_json):
     """Test getting all current parsers."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/parser', 'get',
             aresponses.Response(text=json.dumps(parser_json), status=200))
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -8,7 +8,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PORT, TEST_PASSWORD
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.program import *
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
@@ -16,14 +16,14 @@ from tests.fixtures.provision import provision_name_json, provision_wifi_json
 
 @pytest.mark.asyncio
 async def test_program_enable_disable(
-        aresponses, authenticated_client, event_loop, program_post_json):
+        aresponses, authenticated_local_client, event_loop, program_post_json):
     """Test enabling a program."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program/1', 'post',
             aresponses.Response(
                 text=json.dumps(program_post_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program/1', 'post',
             aresponses.Response(
                 text=json.dumps(program_post_json), status=200))
@@ -45,10 +45,10 @@ async def test_program_enable_disable(
 
 @pytest.mark.asyncio
 async def test_program_get(
-        aresponses, authenticated_client, event_loop, program_json):
+        aresponses, authenticated_local_client, event_loop, program_json):
     """Test getting all programs."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program', 'get',
             aresponses.Response(text=json.dumps(program_json), status=200))
 
@@ -67,10 +67,10 @@ async def test_program_get(
 
 @pytest.mark.asyncio
 async def test_program_get_active(
-        aresponses, authenticated_client, event_loop, program_json):
+        aresponses, authenticated_local_client, event_loop, program_json):
     """Test getting only active programs."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program', 'get',
             aresponses.Response(text=json.dumps(program_json), status=200))
 
@@ -89,10 +89,10 @@ async def test_program_get_active(
 
 @pytest.mark.asyncio
 async def test_program_get_by_id(
-        aresponses, authenticated_client, event_loop, program_id_json):
+        aresponses, authenticated_local_client, event_loop, program_id_json):
     """Test getting a program by its ID."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program/1', 'get',
             aresponses.Response(text=json.dumps(program_id_json), status=200))
 
@@ -110,11 +110,11 @@ async def test_program_get_by_id(
 
 @pytest.mark.asyncio
 async def test_program_next_run(
-        aresponses, authenticated_client, event_loop, program_nextrun_json,
+        aresponses, authenticated_local_client, event_loop, program_nextrun_json,
         program_start_stop_json, watering_program_json):
     """Test getting the next run of a program."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program/nextrun',
             'get',
             aresponses.Response(
@@ -134,10 +134,10 @@ async def test_program_next_run(
 
 @pytest.mark.asyncio
 async def test_program_running(
-        aresponses, authenticated_client, event_loop, watering_program_json):
+        aresponses, authenticated_local_client, event_loop, watering_program_json):
     """Test getting all running programs."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/program',
             'get',
             aresponses.Response(
@@ -158,15 +158,15 @@ async def test_program_running(
 
 @pytest.mark.asyncio
 async def test_program_start_and_stop(
-        aresponses, authenticated_client, event_loop, program_start_stop_json):
+        aresponses, authenticated_local_client, event_loop, program_start_stop_json):
     """Test starting and stopping a program."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program/1/start',
             'post',
             aresponses.Response(
                 text=json.dumps(program_start_stop_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/program/1/stop',
             'post',
             aresponses.Response(

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -8,26 +8,26 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.provision import *
 
 
 @pytest.mark.asyncio
 async def test_endpoints(
-        aresponses, authenticated_client, event_loop, provision_json,
+        aresponses, authenticated_local_client, event_loop, provision_json,
         provision_name_json, provision_wifi_json):
     """Test getting all provisioning data."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision', 'get',
             aresponses.Response(text=json.dumps(provision_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision/name',
             'get',
             aresponses.Response(
                 text=json.dumps(provision_name_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/provision/wifi',
             'get',
             aresponses.Response(

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -8,7 +8,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
 from tests.fixtures.restrictions import *
@@ -16,11 +16,11 @@ from tests.fixtures.restrictions import *
 
 @pytest.mark.asyncio
 async def test_restrictions_current(
-        aresponses, authenticated_client, event_loop,
+        aresponses, authenticated_local_client, event_loop,
         restrictions_currently_json):
     """Test getting any current restrictions."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/restrictions/currently', 'get',
             aresponses.Response(
@@ -40,11 +40,11 @@ async def test_restrictions_current(
 
 @pytest.mark.asyncio
 async def test_restrictions_global(
-        aresponses, authenticated_client, event_loop,
+        aresponses, authenticated_local_client, event_loop,
         restrictions_global_json):
     """Test getting any global restrictions."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/restrictions/global', 'get',
             aresponses.Response(
@@ -64,11 +64,11 @@ async def test_restrictions_global(
 
 @pytest.mark.asyncio
 async def test_restrictions_hourly(
-        aresponses, authenticated_client, event_loop,
+        aresponses, authenticated_local_client, event_loop,
         restrictions_hourly_json):
     """Test getting any hourly restrictions."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/restrictions/hourly', 'get',
             aresponses.Response(
@@ -88,11 +88,11 @@ async def test_restrictions_hourly(
 
 @pytest.mark.asyncio
 async def test_restrictions_raindelay(
-        aresponses, authenticated_client, event_loop,
+        aresponses, authenticated_local_client, event_loop,
         restrictions_raindelay_json):
     """Test getting any rain delay-related restrictions."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/restrictions/raindelay', 'get',
             aresponses.Response(

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -9,7 +9,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
 from tests.fixtures.stats import *
@@ -17,19 +17,19 @@ from tests.fixtures.stats import *
 
 @pytest.mark.asyncio
 async def test_stats(
-        aresponses, authenticated_client, dailystats_date_json,
+        aresponses, authenticated_local_client, dailystats_date_json,
         dailystats_details_json, event_loop):
     """Test getting states (with or without details)."""
     today = date.today()
     today_str = today.strftime('%Y-%m-%d')
 
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/dailystats/{0}'.format(today_str), 'get',
             aresponses.Response(
                 text=json.dumps(dailystats_date_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/dailystats/details', 'get',
             aresponses.Response(

--- a/tests/test_watering.py
+++ b/tests/test_watering.py
@@ -10,7 +10,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
 from tests.fixtures.watering import *
@@ -18,13 +18,13 @@ from tests.fixtures.watering import *
 
 @pytest.mark.asyncio
 async def test_watering_log_details(
-        aresponses, authenticated_client, event_loop, watering_log_json):
+        aresponses, authenticated_local_client, event_loop, watering_log_json):
     """Test getting watering log details."""
     today = datetime.date.today()
     today_str = today.strftime('%Y-%m-%d')
 
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/watering/log/details/{0}/{1}'.format(today_str, 2), 'get',
             aresponses.Response(
@@ -44,15 +44,15 @@ async def test_watering_log_details(
 
 @pytest.mark.asyncio
 async def test_watering_pause(
-        aresponses, authenticated_client, event_loop, watering_pause_json):
+        aresponses, authenticated_local_client, event_loop, watering_pause_json):
     """Test pausing and unpausing watering."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/pauseall',
             'post',
             aresponses.Response(
                 text=json.dumps(watering_pause_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/pauseall',
             'post',
             aresponses.Response(
@@ -75,10 +75,10 @@ async def test_watering_pause(
 
 @pytest.mark.asyncio
 async def test_watering_queue(
-        aresponses, authenticated_client, event_loop, watering_queue_json):
+        aresponses, authenticated_local_client, event_loop, watering_queue_json):
     """Test getting the watering queue."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/queue',
             'get',
             aresponses.Response(
@@ -98,13 +98,13 @@ async def test_watering_queue(
 
 @pytest.mark.asyncio
 async def test_watering_past(
-        aresponses, authenticated_client, event_loop, watering_past_json):
+        aresponses, authenticated_local_client, event_loop, watering_past_json):
     """Test gettinng info on past watering runs."""
     today = datetime.date.today()
     today_str = today.strftime('%Y-%m-%d')
 
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT),
             '/api/4/watering/past/{0}/{1}'.format(today_str, 2), 'get',
             aresponses.Response(
@@ -124,10 +124,10 @@ async def test_watering_past(
 
 @pytest.mark.asyncio
 async def test_watering_stop(
-        aresponses, authenticated_client, event_loop, watering_stopall_json):
+        aresponses, authenticated_local_client, event_loop, watering_stopall_json):
     """Test stopping all watering activities."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/watering/stopall',
             'post',
             aresponses.Response(

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -9,7 +9,7 @@ import pytest
 from regenmaschine import login
 
 from tests.const import TEST_HOST, TEST_PASSWORD, TEST_PORT
-from tests.fixtures import authenticated_client, auth_login_json
+from tests.fixtures import authenticated_local_client, auth_login_json
 from tests.fixtures.api import apiver_json
 from tests.fixtures.provision import provision_name_json, provision_wifi_json
 from tests.fixtures.zone import *
@@ -17,14 +17,14 @@ from tests.fixtures.zone import *
 
 @pytest.mark.asyncio
 async def test_zone_enable_disable(
-        aresponses, authenticated_client, event_loop, zone_post_json):
+        aresponses, authenticated_local_client, event_loop, zone_post_json):
     """Test enabling a zone."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/1/properties',
             'post',
             aresponses.Response(text=json.dumps(zone_post_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/1/properties',
             'post',
             aresponses.Response(text=json.dumps(zone_post_json), status=200))
@@ -46,10 +46,10 @@ async def test_zone_enable_disable(
 
 @pytest.mark.asyncio
 async def test_zone_get(
-        aresponses, authenticated_client, event_loop, zone_properties_json):
+        aresponses, authenticated_local_client, event_loop, zone_properties_json):
     """Test getting info on all zones."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/properties',
             'get',
             aresponses.Response(
@@ -70,10 +70,10 @@ async def test_zone_get(
 
 @pytest.mark.asyncio
 async def test_zone_get_active(
-        aresponses, authenticated_client, event_loop, zone_properties_json):
+        aresponses, authenticated_local_client, event_loop, zone_properties_json):
     """Test getting info on active zones."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/properties',
             'get',
             aresponses.Response(
@@ -94,10 +94,10 @@ async def test_zone_get_active(
 
 @pytest.mark.asyncio
 async def test_zone_get_by_id(
-        aresponses, authenticated_client, event_loop, zone_id_properties_json):
+        aresponses, authenticated_local_client, event_loop, zone_id_properties_json):
     """Test getting properties on a specific zone by ID."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/1/properties',
             'get',
             aresponses.Response(
@@ -117,15 +117,15 @@ async def test_zone_get_by_id(
 
 @pytest.mark.asyncio
 async def test_zone_start_stop(
-        aresponses, authenticated_client, event_loop, zone_start_stop_json):
+        aresponses, authenticated_local_client, event_loop, zone_start_stop_json):
     """Test starting and stopping a zone."""
-    async with authenticated_client:
-        authenticated_client.add(
+    async with authenticated_local_client:
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/1/start',
             'post',
             aresponses.Response(
                 text=json.dumps(zone_start_stop_json), status=200))
-        authenticated_client.add(
+        authenticated_local_client.add(
             '{0}:{1}'.format(TEST_HOST, TEST_PORT), '/api/4/zone/1/stop',
             'post',
             aresponses.Response(


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a `RemoteController` to manage the RainMachine API remotely.

**Does this fix a specific issue?**

Addresses part of #34.
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)