### PR TITLE
Add "Connection: close" to all requests

### DIFF
--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -103,7 +103,7 @@ class Client:  # pylint: disable=too-few-public-methods
 
         if not headers:
             headers = {}
-        headers.update({"Content-Type": "application/json"})
+        headers.update({"Connection": "close", "Content-Type": "application/json"})
 
         if not params:
             params = {}


### PR DESCRIPTION
**Describe what the PR does:**

[Home Assistant's RainMachine integration was throwing lots of weird exceptions](https://github.com/home-assistant/home-assistant/issues/23650). At regular intervals, we'd see logs like this:

```
2019-05-03 04:31:12 ERROR (MainThread) [homeassistant.components.rainmachine.switch] Unable to update info for zone "60e32719b6cf_zone_6": Error requesting data from 192.168.1.100: None
```

It appears that after some amount of time, the RainMachine forcibly closes the HTTP socket that `regenmaschine` uses; as a result, that request fails and it takes _another_ request to establish a new socket. This PR modifies the client so that every request as the `Connection: close` header, which will force the connection to close each time. We might miss out on some tiny speed increases by recreating the connection each time, but it shouldn't be noticeable.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
