### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/regenmaschine/api.py
+++ b/regenmaschine/api.py
@@ -7,7 +7,7 @@ class API:  # pylint: disable=too-few-public-methods
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def versions(self) -> dict:
         """Get software, hardware, and API versions."""

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -13,8 +13,8 @@ from regenmaschine.stats import Stats
 from regenmaschine.watering import Watering
 from regenmaschine.zone import Zone
 
-URL_BASE_LOCAL = "https://{0}:{1}/api/4"
-URL_BASE_REMOTE = "https://api.rainmachine.com/{0}/api/4"
+URL_BASE_LOCAL: str = "https://{0}:{1}/api/4"
+URL_BASE_REMOTE: str = "https://api.rainmachine.com/{0}/api/4"
 
 
 class Controller:  # pylint: disable=too-many-instance-attributes
@@ -22,36 +22,36 @@ class Controller:  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._access_token = None  # type: Optional[str]
-        self._access_token_expiration = None  # type: Optional[datetime]
-        self._client_request = request
-        self._host = None  # type: Optional[str]
-        self._ssl = True
-        self.api_version = None  # type: Optional[str]
-        self.hardware_version = None  # type: Optional[int]
-        self.mac = None
-        self.name = None  # type: Optional[str]
-        self.software_version = None  # type: Optional[str]
+        self._access_token: Optional[str] = None
+        self._access_token_expiration: Optional[datetime] = None
+        self._client_request: Callable[..., Awaitable[dict]] = request
+        self._host: Optional[str] = None
+        self._ssl: bool = True
+        self.api_version: Optional[str] = None
+        self.hardware_version: Optional[int] = None
+        self.mac: Optional[str] = None
+        self.name: Optional[str] = None
+        self.software_version: Optional[str] = None
 
         # API endpoints:
-        self.api = API(self._request)
-        self.diagnostics = Diagnostics(self._request)
-        self.parsers = Parser(self._request)
-        self.programs = Program(self._request)
-        self.provisioning = Provision(self._request)
-        self.restrictions = Restriction(self._request)
-        self.stats = Stats(self._request)
-        self.watering = Watering(self._request)
-        self.zones = Zone(self._request)
+        self.api: API = API(self._request)
+        self.diagnostics: Diagnostics = Diagnostics(self._request)
+        self.parsers: Parser = Parser(self._request)
+        self.programs: Program = Program(self._request)
+        self.provisioning: Provision = Provision(self._request)
+        self.restrictions: Restriction = Restriction(self._request)
+        self.stats: Stats = Stats(self._request)
+        self.watering: Watering = Watering(self._request)
+        self.zones: Zone = Zone(self._request)
 
     async def _request(
         self,
         method: str,
         endpoint: str,
         *,
-        headers: dict = None,
-        params: dict = None,
-        json: dict = None,
+        headers: Optional[dict] = None,
+        params: Optional[dict] = None,
+        json: Optional[dict] = None,
         ssl: bool = True,
     ) -> dict:
         """Wrap the generic request method to add access token, etc."""
@@ -76,17 +76,17 @@ class LocalController(Controller):
         """Initialize."""
         super().__init__(request)
 
-        self._host = URL_BASE_LOCAL.format(host, port)
-        self._ssl = ssl
+        self._host: str = URL_BASE_LOCAL.format(host, port)
+        self._ssl: bool = ssl
 
     async def login(self, password):
         """Authenticate against the device (locally)."""
-        auth_resp = await self._client_request(
+        auth_resp: dict = await self._client_request(
             "post", f"{self._host}/auth/login", json={"pwd": password, "remember": 1}
         )
 
-        self._access_token = auth_resp["access_token"]
-        self._access_token_expiration = datetime.now() + timedelta(
+        self._access_token: str = auth_resp["access_token"]
+        self._access_token_expiration: datetime = datetime.now() + timedelta(
             seconds=int(auth_resp["expires_in"]) - 10
         )
 
@@ -98,12 +98,12 @@ class RemoteController(Controller):
         self, stage_1_access_token: str, sprinkler_id: str, password: str
     ) -> None:
         """Authenticate against the device (remotely)."""
-        auth_resp = await self._client_request(
+        auth_resp: dict = await self._client_request(
             "post",
             "https://my.rainmachine.com/devices/login-sprinkler",
             access_token=stage_1_access_token,
             json={"sprinklerId": sprinkler_id, "pwd": password},
         )
 
-        self._access_token = auth_resp["access_token"]
-        self._host = URL_BASE_REMOTE.format(sprinkler_id)
+        self._access_token: str = auth_resp["access_token"]
+        self._host: str = URL_BASE_REMOTE.format(sprinkler_id)

--- a/regenmaschine/diagnostics.py
+++ b/regenmaschine/diagnostics.py
@@ -7,7 +7,7 @@ class Diagnostics:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def current(self) -> dict:
         """Get current diagnostics."""
@@ -15,5 +15,5 @@ class Diagnostics:
 
     async def log(self) -> dict:
         """Get the device log."""
-        data = await self._request("get", "diag/log")
+        data: dict = await self._request("get", "diag/log")
         return data["log"]

--- a/regenmaschine/errors.py
+++ b/regenmaschine/errors.py
@@ -25,7 +25,7 @@ ERROR_CODES = {1: "The email has not been validated"}
 def raise_remote_error(error_code: int) -> None:
     """Raise the appropriate error with a remote error code."""
     try:
-        error = next((v for k, v in ERROR_CODES.items() if k == error_code))
+        error: str = next((v for k, v in ERROR_CODES.items() if k == error_code))
         raise RequestError(error)
     except StopIteration:
         raise RequestError(f"Unknown remote error code returned: {error_code}")

--- a/regenmaschine/parser.py
+++ b/regenmaschine/parser.py
@@ -7,9 +7,9 @@ class Parser:  # pylint: disable=too-few-public-methods
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def current(self) -> dict:
         """Get current diagnostics."""
-        data = await self._request("get", "parser")
+        data: dict = await self._request("get", "parser")
         return data["parsers"]

--- a/regenmaschine/program.py
+++ b/regenmaschine/program.py
@@ -7,7 +7,7 @@ class Program:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def _post(self, program_id: int = None, json: dict = None) -> dict:
         """Post data to a (non)existing program."""
@@ -15,7 +15,7 @@ class Program:
 
     async def all(self, include_inactive: bool = False) -> list:
         """Return all programs."""
-        data = await self._request("get", "program")
+        data: dict = await self._request("get", "program")
         return [p for p in data["programs"] if include_inactive or p["active"]]
 
     async def disable(self, program_id: int) -> dict:
@@ -32,12 +32,12 @@ class Program:
 
     async def next(self) -> list:
         """Return the next run date/time for all programs."""
-        data = await self._request("get", "program/nextrun")
+        data: dict = await self._request("get", "program/nextrun")
         return data["nextRuns"]
 
     async def running(self) -> list:
         """Return all running programs."""
-        data = await self._request("get", "watering/program")
+        data: dict = await self._request("get", "watering/program")
         return data["programs"]
 
     async def start(self, program_id: int) -> dict:

--- a/regenmaschine/provision.py
+++ b/regenmaschine/provision.py
@@ -7,12 +7,12 @@ class Provision:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     @property
     async def device_name(self) -> str:
         """Get the name of the device."""
-        data = await self._request("get", "provision/name")
+        data: dict = await self._request("get", "provision/name")
         return data["name"]
 
     async def settings(self) -> dict:

--- a/regenmaschine/restriction.py
+++ b/regenmaschine/restriction.py
@@ -7,7 +7,7 @@ class Restriction:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def current(self) -> dict:
         """Get currently active restrictions."""
@@ -15,7 +15,7 @@ class Restriction:
 
     async def hourly(self) -> list:
         """Get a list of restrictions that are active over the next hour."""
-        data = await self._request("get", "restrictions/hourly")
+        data: dict = await self._request("get", "restrictions/hourly")
         return data["hourlyRestrictions"]
 
     async def raindelay(self) -> dict:

--- a/regenmaschine/stats.py
+++ b/regenmaschine/stats.py
@@ -8,7 +8,7 @@ class Stats:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def on_date(self, date: datetime.date) -> dict:
         """Get statistics for a certain date."""
@@ -16,10 +16,10 @@ class Stats:
 
     async def upcoming(self, details: bool = False) -> list:
         """Return watering statistics for the next 6 days."""
-        endpoint = "dailystats"
-        key = "DailyStats"
+        endpoint: str = "dailystats"
+        key: str = "DailyStats"
         if details:
             endpoint += "/details"
             key = "DailyStatsDetails"
-        data = await self._request("get", endpoint)
+        data: dict = await self._request("get", endpoint)
         return data[key]

--- a/regenmaschine/watering.py
+++ b/regenmaschine/watering.py
@@ -8,20 +8,20 @@ class Watering:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def log(
         self, date: datetime.date = None, days: int = None, details: bool = False
     ) -> list:
         """Get watering information for X days from Y date."""
-        endpoint = "watering/log"
+        endpoint: str = "watering/log"
         if details:
             endpoint += "/details"
 
         if date and days:
             endpoint = f"{endpoint}/{date.strftime('%Y-%m-%d')}/{days}"
 
-        data = await self._request("get", endpoint)
+        data: dict = await self._request("get", endpoint)
         return data["waterLog"]["days"]
 
     async def pause_all(self, seconds: int) -> dict:
@@ -32,17 +32,17 @@ class Watering:
 
     async def queue(self) -> list:
         """Return the queue of active watering activities."""
-        data = await self._request("get", "watering/queue")
+        data: dict = await self._request("get", "watering/queue")
         return data["queue"]
 
     async def runs(self, date: datetime.date = None, days: int = None) -> list:
         """Return all program runs for X days from Y date."""
-        endpoint = "watering/past"
+        endpoint: str = "watering/past"
 
         if date and days:
             endpoint = f"{endpoint}/{date.strftime('%Y-%m-%d')}/{days}"
 
-        data = await self._request("get", endpoint)
+        data: dict = await self._request("get", endpoint)
         return data["pastValues"]
 
     async def stop_all(self) -> dict:

--- a/regenmaschine/zone.py
+++ b/regenmaschine/zone.py
@@ -7,7 +7,7 @@ class Zone:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def _post(self, zone_id: int = None, json: dict = None) -> dict:
         """Post data to a (non)existing zone."""
@@ -17,10 +17,10 @@ class Zone:
         self, *, details: bool = False, include_inactive: bool = False
     ) -> list:
         """Return all zones (with optional advanced properties)."""
-        endpoint = "zone"
+        endpoint: str = "zone"
         if details:
             endpoint += "/properties"
-        data = await self._request("get", endpoint)
+        data: dict = await self._request("get", endpoint)
         return [z for z in data["zones"] if include_inactive or z["active"]]
 
     async def disable(self, zone_id: int) -> dict:
@@ -33,7 +33,7 @@ class Zone:
 
     async def get(self, zone_id: int, *, details: bool = False) -> dict:
         """Return a specific zone."""
-        endpoint = f"zone/{zone_id}"
+        endpoint: str = f"zone/{zone_id}"
         if details:
             endpoint += "/properties"
         return await self._request("get", endpoint)


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
