### PR TITLE
Remove deprecated Client login coroutine

### DIFF
--- a/regenmaschine/__init__.py
+++ b/regenmaschine/__init__.py
@@ -1,2 +1,2 @@
 """Initialize."""
-from .client import Client, login  # noqa
+from .client import Client  # noqa

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -139,19 +139,3 @@ def _raise_for_remote_status(url: str, data: dict) -> None:
         raise RequestError(
             f"Error requesting data from {url}: {data['statusCode']} {data['message']}"
         )
-
-
-async def login(
-    host: str,
-    password: str,
-    websession: ClientSession,
-    *,
-    port: int = 8080,
-    ssl: bool = True,
-    request_timeout: int = DEFAULT_TIMEOUT,
-) -> Controller:
-    """Authenticate against a RainMachine device."""
-    _LOGGER.warning("regenmaschine.client.login() is deprecated; see documentation!")
-    client: Client = Client(websession, request_timeout)
-    await client.load_local(host, password, port, ssl)
-    return next(iter(client.controllers.values()))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -21,11 +21,11 @@ async def test_api_versions(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.api.versions()
+            data = await controller.api.versions()
             assert data["apiVer"] == "4.5.0"
             assert data["hwVer"] == 3
             assert data["swVer"] == "4.0.925"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -19,11 +19,11 @@ async def test_diagnostics_current(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.diagnostics.current()
+            data = await controller.diagnostics.current()
             assert data["memUsage"] == 18220
 
 
@@ -41,9 +41,9 @@ async def test_diagnostics_log(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.diagnostics.log()
+            data = await controller.diagnostics.log()
             assert data == "----"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -19,10 +19,10 @@ async def test_parsers_current(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.parsers.current()
+            data = await controller.parsers.current()
             assert len(data) == 1
             assert data[0]["name"] == "NOAA Parser"

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -29,14 +29,14 @@ async def test_program_enable_disable(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            resp = await client.programs.enable(1)
+            resp = await controller.programs.enable(1)
             assert resp["message"] == "OK"
 
-            resp = await client.programs.disable(1)
+            resp = await controller.programs.disable(1)
             assert resp["message"] == "OK"
 
 
@@ -52,11 +52,11 @@ async def test_program_get(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.programs.all(include_inactive=True)
+            data = await controller.programs.all(include_inactive=True)
             assert len(data) == 2
             assert data[0]["name"] == "Morning"
 
@@ -73,11 +73,11 @@ async def test_program_get_active(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.programs.all()
+            data = await controller.programs.all()
             assert len(data) == 1
             assert data[0]["name"] == "Morning"
 
@@ -96,11 +96,11 @@ async def test_program_get_by_id(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.programs.get(1)
+            data = await controller.programs.get(1)
             assert data["name"] == "Morning"
 
 
@@ -118,11 +118,11 @@ async def test_program_next_run(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.programs.next()
+            data = await controller.programs.next()
             assert len(data) == 2
 
 
@@ -140,11 +140,11 @@ async def test_program_running(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.programs.running()
+            data = await controller.programs.running()
             assert len(data) == 1
             assert data[0]["name"] == "Evening"
 
@@ -171,12 +171,12 @@ async def test_program_start_and_stop(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.programs.start(1)
+            data = await controller.programs.start(1)
             assert data["message"] == "OK"
 
-            data = await client.programs.stop(1)
+            data = await controller.programs.stop(1)
             assert data["message"] == "OK"

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -37,13 +37,13 @@ async def test_endpoints(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            name = await client.provisioning.device_name
+            name = await controller.provisioning.device_name
             assert name == "My House"
 
-            data = await client.provisioning.settings()
+            data = await controller.provisioning.settings()
             assert data["system"]["databasePath"] == "/rainmachine-app/DB/Default"
             assert data["location"]["stationName"] == "MY STATION"

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -21,11 +21,11 @@ async def test_restrictions_current(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.restrictions.current()
+            data = await controller.restrictions.current()
             assert data["hourly"] is False
 
 
@@ -43,11 +43,11 @@ async def test_restrictions_global(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.restrictions.universal()
+            data = await controller.restrictions.universal()
             assert data["freezeProtectTemp"] == 2
 
 
@@ -65,11 +65,11 @@ async def test_restrictions_hourly(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.restrictions.hourly()
+            data = await controller.restrictions.hourly()
             assert not data
 
 
@@ -87,9 +87,9 @@ async def test_restrictions_raindelay(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.restrictions.raindelay()
+            data = await controller.restrictions.raindelay()
             assert data["delayCounter"] == -1

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -4,7 +4,7 @@ from datetime import date
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -34,12 +34,12 @@ async def test_stats(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.stats.on_date(today)
+            data = await controller.stats.on_date(today)
             assert data["percentage"] == 100
 
-            data = await client.stats.upcoming(details=True)
+            data = await controller.stats.upcoming(details=True)
             assert len(data[0]["programs"]) == 4

--- a/tests/test_watering.py
+++ b/tests/test_watering.py
@@ -4,7 +4,7 @@ import datetime
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -26,11 +26,11 @@ async def test_watering_log_details(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.watering.log(today, 2, details=True)
+            data = await controller.watering.log(today, 2, details=True)
             assert len(data) == 2
 
 
@@ -56,14 +56,14 @@ async def test_watering_pause(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.watering.pause_all(30)
+            data = await controller.watering.pause_all(30)
             assert data["message"] == "OK"
 
-            data = await client.watering.unpause_all()
+            data = await controller.watering.unpause_all()
             assert data["message"] == "OK"
 
 
@@ -81,11 +81,11 @@ async def test_watering_queue(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.watering.queue()
+            data = await controller.watering.queue()
             assert not data
 
 
@@ -106,11 +106,11 @@ async def test_watering_past(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.watering.runs(today, 2)
+            data = await controller.watering.runs(today, 2)
             assert len(data) == 8
 
 
@@ -128,9 +128,9 @@ async def test_watering_stop(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.watering.stop_all()
+            data = await controller.watering.stop_all()
             assert data["message"] == "OK"

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from regenmaschine import login
+from regenmaschine import Client
 
 from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
 
@@ -29,14 +29,14 @@ async def test_zone_enable_disable(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            resp = await client.zones.enable(1)
+            resp = await controller.zones.enable(1)
             assert resp["message"] == "OK"
 
-            resp = await client.zones.disable(1)
+            resp = await controller.zones.disable(1)
             assert resp["message"] == "OK"
 
 
@@ -54,11 +54,11 @@ async def test_zone_get(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.zones.all(details=True, include_inactive=True)
+            data = await controller.zones.all(details=True, include_inactive=True)
             assert len(data) == 2
             assert data[0]["name"] == "Landscaping"
 
@@ -77,11 +77,11 @@ async def test_zone_get_active(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.zones.all(details=True)
+            data = await controller.zones.all(details=True)
             assert len(data) == 1
             assert data[0]["name"] == "Landscaping"
 
@@ -100,11 +100,11 @@ async def test_zone_get_by_id(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.zones.get(1, details=True)
+            data = await controller.zones.get(1, details=True)
             assert data["name"] == "Landscaping"
 
 
@@ -130,12 +130,12 @@ async def test_zone_start_stop(aresponses, authenticated_local_client):
         )
 
         async with aiohttp.ClientSession() as websession:
-            client = await login(
-                TEST_HOST, TEST_PASSWORD, websession, port=TEST_PORT, ssl=False
-            )
+            client = Client(websession)
+            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            controller = next(iter(client.controllers.values()))
 
-            data = await client.zones.start(1, 60)
+            data = await controller.zones.start(1, 60)
             assert data["message"] == "OK"
 
-            data = await client.zones.stop(1)
+            data = await controller.zones.stop(1)
             assert data["message"] == "OK"


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/regenmaschine/pull/35 deprecated the `Client.login()` coroutine in favor of `Client.load_local()` and `Client.load_remote()`. Enough time has passed, so I'm officiall removing this method.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
