### PR TITLE
Handle asynctest not working in Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
     hooks:
       - id: pydocstyle
         files: ^((regenmaschine|tests)/.+)?[^/]+\.py$
-  - repo: https://github.com/ryanrhee/shellcheck-py
-    rev: v0.7.1.1
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.4
     hooks:
       - id: shellcheck
         args:

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -1,0 +1,9 @@
+"""Define async mocking that works for various Python versions."""
+import sys
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import *  # noqa
+
+    AsyncMock = CoroutineMock  # noqa: F405
+else:
+    from unittest.mock import *  # noqa

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,13 +4,13 @@ import asyncio
 from datetime import datetime, timedelta
 
 import aiohttp
-import asynctest
 import pytest
 
 from regenmaschine import Client
 from regenmaschine.errors import RequestError, TokenExpiredError
 
-from .common import (
+import tests.async_mock as mock
+from tests.common import (
     TEST_ACCESS_TOKEN,
     TEST_API_VERSION,
     TEST_EMAIL,
@@ -238,9 +238,7 @@ async def test_request_timeout(authenticated_local_client):  # noqa: D202
         """Define a method that takes 0.5 seconds to execute."""
         await asyncio.sleep(0.5)
 
-    with asynctest.mock.patch.object(
-        aiohttp.ClientResponse, "json", long_running_login
-    ):
+    with mock.patch.object(aiohttp.ClientResponse, "json", long_running_login):
         async with authenticated_local_client:
             async with aiohttp.ClientSession() as session:
                 with pytest.raises(RequestError):


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes the fact that `asynctest` no longer works in Python 3.8. The PR still ensures that it can be used for Python 3.6 and 3.7.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
