### PR TITLE
Add raising of TokenExpiredError when token explicitly expires

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: mypy
         files: ^regenmaschine/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.3.0
     hooks:
       - id: check-json
       - id: no-commit-to-branch

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -138,6 +138,8 @@ class Client:
                     data = await resp.json(content_type=None)
                     _raise_for_remote_status(url, data)
         except ClientError as err:
+            if "401" in str(err):
+                raise TokenExpiredError("Long-lived access token has expired") from err
             raise RequestError(f"Error requesting data from {url}") from err
         except asyncio.TimeoutError as err:
             raise RequestError(f"Timeout during request: {url}") from err


### PR DESCRIPTION
**Describe what the PR does:**

Previously, the client would raise a `TokenExpiredError` when the token implicitly expired (based on datetime). This PR adds the same raise when the token explicitly expires.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
