### PR TITLE
Ensure no-commit-to-branch hook doesn't run with CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,3 +82,5 @@ jobs:
           architecture: x64
 
       - uses: pre-commit/action@v2.0.0
+        env:
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
**Describe what the PR does:**

`dev` CI is currently failing because it's running the `no-commit-to-branch` pre-commit hook. This PR disables that hook during CI.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
