### PR TITLE
Upgrade aiohttp to a minimum of 3.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-aiohttp = "^3.6.2"
+aiohttp = "^3.7.4"
 python = "^3.6.0"
 
 [tool.poetry.dev-dependencies]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.2
+aiohttp>=3.7.4
 aresponses==1.1.2
 asynctest==0.13.0
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR upgrades `aiohttp` to 3.7.4, which fixes https://github.com/advisories/GHSA-v6wp-4m6f-gcjg.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
