### PR TITLE
Add API to restrict/unrestrict watering activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ async def main() -> None:
             hourly = await controller.restrictions.hourly()
             raindelay = await controller.restrictions.raindelay()
 
+            # Restrict all watering activities for 3 days:
+            await controller.restrictions.restrict(datetime.timedelta(days=3))
+            # ...and then unrestrict watering activities:
+            await controller.restrictions.unrestrict()
+
             # Get watering stats:
             today = await controller.stats.on_date(datetime.date.today())
             upcoming_days = await controller.stats.upcoming(details=True)

--- a/regenmaschine/restriction.py
+++ b/regenmaschine/restriction.py
@@ -1,4 +1,6 @@
 """Define an object to interact with restriction info."""
+from datetime import timedelta
+from time import time
 from typing import Any, Awaitable, Callable, Dict, List, cast
 
 
@@ -22,6 +24,28 @@ class Restriction:
         """Get restriction info related to rain delays."""
         return await self._request("get", "restrictions/raindelay")
 
+    async def restrict(self, duration: timedelta) -> Dict[str, Any]:
+        """Restrict all watering activities for a time period."""
+        return await self._request(
+            "post",
+            "restrictions/global",
+            json={
+                "rainDelayStartTime": round(time()),
+                "rainDelayDuration": duration.total_seconds(),
+            },
+        )
+
     async def universal(self) -> Dict[str, Any]:
         """Get global (always active) restrictions."""
         return await self._request("get", "restrictions/global")
+
+    async def unrestrict(self) -> Dict[str, Any]:
+        """Unrestrict all watering activities."""
+        return await self._request(
+            "post",
+            "restrictions/global",
+            json={
+                "rainDelayStartTime": round(time()),
+                "rainDelayDuration": 0,
+            },
+        )

--- a/tests/fixtures/restrict_response.json
+++ b/tests/fixtures/restrict_response.json
@@ -1,0 +1,4 @@
+{
+	"statusCode": 0,
+	"message": "OK"
+}

--- a/tests/fixtures/unrestrict_response.json
+++ b/tests/fixtures/unrestrict_response.json
@@ -1,0 +1,4 @@
+{
+	"statusCode": 0,
+	"message": "OK"
+}


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds API calls to restrict watering activities for a time and unrestrict them later. This is equivalent to the "Snooze" page in the RainMachine web GUI:

<img width="1264" alt="CleanShot 2022-01-16 at 16 20 12@2x" src="https://user-images.githubusercontent.com/47216/149682243-1d383d24-e0b9-4d61-b838-815120e58dde.png">

**Does this fix a specific issue?**

Fixes https://github.com/bachya/regenmaschine/issues/114
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
