### PR TITLE
Return data payload when API request fails

### DIFF
--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -106,6 +106,8 @@ class Client:
         **kwargs: Dict[str, Any],
     ) -> Dict[str, Any]:
         """Make a request with a session."""
+        data: Dict[str, Any] = {}
+
         try:
             async with async_timeout.timeout(self._request_timeout), session.request(
                 method, url, ssl=ssl, **kwargs

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -110,15 +110,17 @@ class Client:
             async with async_timeout.timeout(self._request_timeout), session.request(
                 method, url, ssl=ssl, **kwargs
             ) as resp:
-                resp.raise_for_status()
                 data = await resp.json(content_type=None)
+                resp.raise_for_status()
                 _raise_for_remote_status(url, data)
         except ServerDisconnectedError:
             raise
         except ClientError as err:
             if "401" in str(err):
                 raise TokenExpiredError("Long-lived access token has expired") from err
-            raise RequestError(f"Error requesting data from {url}: {err}") from err
+            raise RequestError(
+                f"Error requesting data from {url}: {err} (data: {data})"
+            ) from err
         except asyncio.TimeoutError as err:
             raise RequestError(f"Timmed out while requesting data from {url}") from err
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that a failed API request exception contains the response data.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
