### PR TITLE
Add ability for local controller to fall back to older TLS version

### DIFF
--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-<<<<<<< HEAD
-import logging
 from typing import Any
-=======
-from typing import Any, Dict, Optional, cast
->>>>>>> 87cdb7efa2ad (Logging)
 
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError, ServerDisconnectedError

--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+<<<<<<< HEAD
 import logging
 from typing import Any
+=======
+from typing import Any, Dict, Optional, cast
+>>>>>>> 87cdb7efa2ad (Logging)
 
 from aiohttp import ClientSession, ClientTimeout
 from aiohttp.client_exceptions import ClientError, ServerDisconnectedError
 import async_timeout
 
+from regenmaschine.const import LOGGER
 from regenmaschine.controller import Controller, LocalController, RemoteController
 from regenmaschine.errors import RequestError, TokenExpiredError, raise_remote_error
-
-_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 DEFAULT_LOCAL_PORT: int = 8080
 DEFAULT_TIMEOUT: int = 30
@@ -128,7 +131,7 @@ class Client:
         except asyncio.TimeoutError as err:
             raise RequestError(f"Timmed out while requesting data from {url}") from err
 
-        _LOGGER.debug("Data received for %s: %s", url, data)
+        LOGGER.debug("Data received for %s: %s", url, data)
 
         return data
 

--- a/regenmaschine/const.py
+++ b/regenmaschine/const.py
@@ -1,0 +1,4 @@
+"""Define package constants."""
+import logging
+
+LOGGER = logging.getLogger(__package__)

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -6,6 +6,7 @@ from ssl import SSLContext, SSLError, TLSVersion, create_default_context
 from typing import Any, Awaitable, Callable
 
 from regenmaschine.api import API
+from regenmaschine.const import LOGGER
 from regenmaschine.diagnostics import Diagnostics
 from regenmaschine.parser import Parser
 from regenmaschine.program import Program
@@ -59,10 +60,13 @@ class Controller:  # pylint: disable=too-many-instance-attributes
                 ssl=self._ssl_context,
                 **kwargs,
             )
-        except SSLError:
+        except SSLError as err:
             # Some older local controllers don't utilize a modern TLS version; if we
             # encounter a TLS handshake error, attempt to downgrade and try again:
             assert self._ssl_context
+
+            LOGGER.warning("SSL error: %s (attempting TLS downgrade)", err)
+
             self._ssl_context.minimum_version = TLSVersion.SSLv3
             return await self._client_request(
                 method,

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from ssl import SSLContext, SSLError, TLSVersion, create_default_context
+from ssl import CERT_NONE, SSLContext, SSLError, TLSVersion, create_default_context
 from typing import Any, Awaitable, Callable
 
 from regenmaschine.api import API
@@ -88,7 +88,14 @@ class LocalController(Controller):
         super().__init__(request)
 
         self._host = URL_BASE_LOCAL.format(host, port)
-        if not ssl:
+
+        if ssl:
+            # If SSL is enabled, we set options so that the controller's self-signed
+            # cert is accepted:
+            assert self._ssl_context
+            self._ssl_context.check_hostname = False
+            self._ssl_context.verify_mode = CERT_NONE
+        else:
             self._ssl_context = None
 
     async def login(self, password: str) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

It appears that Gen 1 controllers utilize SSLv3; Python 3.10 no longer supports that as a minimum TLS version by default. This PR adjusts things so that if a local controller runs into a TLS error, it attempts to downgrade the TLS type.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
