### PR TITLE
Force inclusion of SSLv3 to support Gen 1 controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ async def main() -> None:
     async with ClientSession() as session:
         client = Client(session=session)
 
-        await client.load_local("192.168.1.101", "my_password", port=8080, ssl=True)
+        await client.load_local("192.168.1.101", "my_password", port=8080, use_ssl=True)
 
         controllers = client.controllers
         # >>> {'ab:cd:ef:12:34:56': <LocalController>}
@@ -176,7 +176,7 @@ async def main() -> None:
         client = Client(session=session)
 
         # Load a local controller:
-        await client.load_local("192.168.1.101", "my_password", port=8080, ssl=True)
+        await client.load_local("192.168.1.101", "my_password", port=8080, use_ssl=True)
 
         # Load all remote controllers associated with an account:
         await client.load_remote("rainmachine_email@host.com", "my_password")

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -27,7 +27,7 @@ class Controller:  # pylint: disable=too-many-instance-attributes
         self._access_token_expiration: datetime | None = None
         self._client_request = request
         self._host: str = ""
-        self._ssl = True
+        self._use_ssl = True
         self.api_version: str = ""
         self.hardware_version: int = 0
         self.mac: str = ""
@@ -54,7 +54,7 @@ class Controller:  # pylint: disable=too-many-instance-attributes
             f"{self._host}/{endpoint}",
             access_token=self._access_token,
             access_token_expiration=self._access_token_expiration,
-            ssl=self._ssl,
+            use_ssl=self._use_ssl,
             **kwargs,
         )
 
@@ -63,13 +63,17 @@ class LocalController(Controller):
     """Define a controller accessed over the LAN."""
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, request: Callable[..., Awaitable[dict]], host: str, port: int, ssl: bool
+        self,
+        request: Callable[..., Awaitable[dict]],
+        host: str,
+        port: int,
+        use_ssl: bool = True,
     ) -> None:
         """Initialize."""
         super().__init__(request)
 
         self._host = URL_BASE_LOCAL.format(host, port)
-        self._ssl = ssl
+        self._use_ssl = use_ssl
 
     async def login(self, password: str) -> None:
         """Authenticate against the device (locally)."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,9 @@ async def test_api_versions(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.api.versions()
@@ -45,7 +47,7 @@ async def test_api_versions_no_explicit_session(aresponses, authenticated_local_
         )
 
         client = Client()
-        await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+        await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False)
         controller = next(iter(client.controllers.values()))
 
         data = await controller.api.versions()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,7 +31,9 @@ async def test_legacy_login(authenticated_local_client):
     async with authenticated_local_client:
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             assert controller._access_token == TEST_ACCESS_TOKEN
@@ -242,7 +244,7 @@ async def test_request_timeout(authenticated_local_client):  # noqa: D202
                 with pytest.raises(RequestError):
                     client = Client(session=session, request_timeout=0.1)
                     await client.load_local(
-                        TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False
+                        TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
                     )
 
 
@@ -272,7 +274,7 @@ async def test_token_expired_implicit_exception(authenticated_local_client):
             async with aiohttp.ClientSession() as session:
                 client = Client(session=session)
                 await client.load_local(
-                    TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False
+                    TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
                 )
                 controller = next(iter(client.controllers.values()))
 
@@ -299,7 +301,9 @@ async def test_retry_only_once_on_server_disconnected(
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
             patcher = None
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -20,7 +20,9 @@ async def test_diagnostics_current(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.diagnostics.current()
@@ -42,7 +44,9 @@ async def test_diagnostics_log(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.diagnostics.log()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,7 +20,9 @@ async def test_parsers_current(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.parsers.current()
@@ -43,7 +45,9 @@ async def test_parsers_post_data(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
             payload = load_fixture("parser_post_data_payload.json")
             data = await controller.parsers.post_data(payload)

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -30,7 +30,9 @@ async def test_program_enable_disable(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             resp = await controller.programs.enable(1)
@@ -53,7 +55,9 @@ async def test_program_get(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             programs = await controller.programs.all(include_inactive=True)
@@ -74,7 +78,9 @@ async def test_program_get_active(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             programs = await controller.programs.all()
@@ -97,7 +103,9 @@ async def test_program_get_by_id(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.programs.get(1)
@@ -119,7 +127,9 @@ async def test_program_next_run(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.programs.next()
@@ -141,7 +151,9 @@ async def test_program_running(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.programs.running()
@@ -172,7 +184,9 @@ async def test_program_start_and_stop(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.programs.start(1)

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -38,7 +38,9 @@ async def test_endpoints(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             name = await controller.provisioning.device_name

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -32,7 +32,9 @@ async def test_restrict_unrestrict(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             await controller.restrictions.restrict(timedelta(hours=15))
@@ -54,7 +56,9 @@ async def test_restrictions_hourly(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.restrictions.hourly()
@@ -76,7 +80,9 @@ async def test_restrictions_raindelay(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.restrictions.raindelay()
@@ -98,7 +104,9 @@ async def test_restrictions_current(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.restrictions.current()
@@ -120,7 +128,9 @@ async def test_restrictions_global(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.restrictions.universal()
@@ -142,7 +152,9 @@ async def test_restrictions_hourly(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.restrictions.hourly()
@@ -164,7 +176,9 @@ async def test_restrictions_raindelay(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.restrictions.raindelay()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -35,7 +35,9 @@ async def test_stats(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.stats.on_date(today)

--- a/tests/test_watering.py
+++ b/tests/test_watering.py
@@ -27,7 +27,9 @@ async def test_watering_log_details(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.watering.log(today, 2, details=True)
@@ -57,7 +59,9 @@ async def test_watering_pause(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.watering.pause_all(30)
@@ -85,7 +89,9 @@ async def test_watering_queue(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.watering.queue()
@@ -110,7 +116,9 @@ async def test_watering_past(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.watering.runs(today, 2)
@@ -132,7 +140,9 @@ async def test_watering_stop(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.watering.stop_all()

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -30,7 +30,9 @@ async def test_zone_enable_disable(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             resp = await controller.zones.enable(1)
@@ -56,7 +58,9 @@ async def test_zone_get(aresponses, authenticated_local_client, zone_fixture_fil
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             zones = await controller.zones.all(include_inactive=True)
@@ -91,7 +95,9 @@ async def test_zone_get_detail(
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             zones = await controller.zones.all(details=True)
@@ -114,7 +120,9 @@ async def test_zone_get_by_id(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.zones.get(1)
@@ -142,7 +150,9 @@ async def test_zone_get_by_id_details(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.zones.get(1, details=True)
@@ -172,7 +182,9 @@ async def test_zone_start_stop(aresponses, authenticated_local_client):
 
         async with aiohttp.ClientSession() as session:
             client = Client(session=session)
-            await client.load_local(TEST_HOST, TEST_PASSWORD, port=TEST_PORT, ssl=False)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
             controller = next(iter(client.controllers.values()))
 
             data = await controller.zones.start(1, 60)


### PR DESCRIPTION
**Describe what the PR does:**

[Python 3.10 increased the minimum supported TLS version to 1.2](https://bugs.python.org/issue43998) (rightly so). However, I recently learned that Gen 1 controllers are still using SSLv3 (and there are no indications that this will be updated), which causes `regenmaschine` to break. This PR reinstates SSLv3 as the minimum supported version.

This is technically a breaking change because it slightly modifies the method signatures of a few methods (`use_ssl` instead of `ssl`).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
