### PR TITLE
Add an endpoint to handle machine-related operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ async def main() -> None:
             # Stop all watering activities:
             await controller.watering.stop_all()
 
+            # See if a firmware update is available:
+            update_data = await controller.machine.get_firmware_update_status()
+            # ...and request the update:
+            update_data = await controller.machine.update_firmware()
+
+            # Reboot the controller:
+            update_data = await controller.machine.reboot()
+
 
 asyncio.run(main())
 ```

--- a/regenmaschine/controller.py
+++ b/regenmaschine/controller.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable
 
 from regenmaschine.api import API
 from regenmaschine.diagnostics import Diagnostics
+from regenmaschine.machine import Machine
 from regenmaschine.parser import Parser
 from regenmaschine.program import Program
 from regenmaschine.provision import Provision
@@ -37,6 +38,7 @@ class Controller:  # pylint: disable=too-many-instance-attributes
         # API endpoints:
         self.api = API(self._request)
         self.diagnostics = Diagnostics(self._request)
+        self.machine = Machine(self._request)
         self.parsers = Parser(self._request)
         self.programs = Program(self._request)
         self.provisioning = Provision(self._request)

--- a/regenmaschine/machine.py
+++ b/regenmaschine/machine.py
@@ -1,0 +1,29 @@
+"""Define an object to interact with machine info."""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+
+class Machine:  # pylint: disable=too-few-public-methods
+    """Define an API object."""
+
+    def __init__(self, request: Callable[..., Awaitable[dict[str, Any]]]) -> None:
+        """Initialize."""
+        self._request = request
+
+    async def _handle_firmware_request(self, method: str) -> dict[str, Any]:
+        """Handle a firmware-related request."""
+        await self._request("post", "machine/update/check")
+        return await self._request(method, "machine/update")
+
+    async def get_firmware_update_status(self) -> dict[str, Any]:
+        """Get the status of any pending firmware updates."""
+        return await self._handle_firmware_request("get")
+
+    async def reboot(self) -> dict[str, Any]:
+        """Reboot the controller."""
+        return await self._request("post", "machine/reboot")
+
+    async def update_firmware(self) -> dict[str, Any]:
+        """Attempt to start the firmware update."""
+        return await self._handle_firmware_request("post")

--- a/tests/fixtures/machine_check_update_response.json
+++ b/tests/fixtures/machine_check_update_response.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 0,
+  "message": "OK"
+}

--- a/tests/fixtures/machine_get_update_response.json
+++ b/tests/fixtures/machine_get_update_response.json
@@ -1,0 +1,7 @@
+{
+  "lastUpdateCheckTimestamp": 1657825288,
+  "packageDetails": [],
+  "update": false,
+  "lastUpdateCheck": "2022-07-14 13:01:28",
+  "updateStatus": 1
+}

--- a/tests/fixtures/machine_reboot_response.json
+++ b/tests/fixtures/machine_reboot_response.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 0,
+  "message": "OK"
+}

--- a/tests/fixtures/machine_update_response.json
+++ b/tests/fixtures/machine_update_response.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 0,
+  "message": "OK"
+}

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -1,0 +1,96 @@
+"""Define tests for api endpoints."""
+import aiohttp
+import pytest
+
+from regenmaschine import Client
+
+from .common import TEST_HOST, TEST_PASSWORD, TEST_PORT, load_fixture
+
+
+@pytest.mark.asyncio
+async def test_get_firmware_update_status(aresponses, authenticated_local_client):
+    """Test getting the status of a firmware update."""
+    async with authenticated_local_client:
+        authenticated_local_client.add(
+            f"{TEST_HOST}:{TEST_PORT}",
+            "/api/4/machine/update/check",
+            "post",
+            aresponses.Response(
+                text=load_fixture("machine_check_update_response.json"), status=200
+            ),
+        )
+        authenticated_local_client.add(
+            f"{TEST_HOST}:{TEST_PORT}",
+            "/api/4/machine/update",
+            "get",
+            aresponses.Response(
+                text=load_fixture("machine_get_update_response.json"), status=200
+            ),
+        )
+
+        async with aiohttp.ClientSession() as session:
+            client = Client(session=session)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
+            controller = next(iter(client.controllers.values()))
+
+            data = await controller.machine.get_firmware_update_status()
+            assert data["update"] is False
+            assert data["updateStatus"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reboot(aresponses, authenticated_local_client):
+    """Test requesting a reboot."""
+    async with authenticated_local_client:
+        authenticated_local_client.add(
+            f"{TEST_HOST}:{TEST_PORT}",
+            "/api/4/machine/reboot",
+            "post",
+            aresponses.Response(
+                text=load_fixture("machine_reboot_response.json"), status=200
+            ),
+        )
+
+        async with aiohttp.ClientSession() as session:
+            client = Client(session=session)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
+            controller = next(iter(client.controllers.values()))
+
+            data = await controller.machine.reboot()
+            assert data["message"] == "OK"
+
+
+@pytest.mark.asyncio
+async def test_update_firmware(aresponses, authenticated_local_client):
+    """Test requesting a firmware update."""
+    async with authenticated_local_client:
+        authenticated_local_client.add(
+            f"{TEST_HOST}:{TEST_PORT}",
+            "/api/4/machine/update/check",
+            "post",
+            aresponses.Response(
+                text=load_fixture("machine_check_update_response.json"), status=200
+            ),
+        )
+        authenticated_local_client.add(
+            f"{TEST_HOST}:{TEST_PORT}",
+            "/api/4/machine/update",
+            "post",
+            aresponses.Response(
+                text=load_fixture("machine_update_response.json"), status=200
+            ),
+        )
+
+        async with aiohttp.ClientSession() as session:
+            client = Client(session=session)
+            await client.load_local(
+                TEST_HOST, TEST_PASSWORD, port=TEST_PORT, use_ssl=False
+            )
+            controller = next(iter(client.controllers.values()))
+
+            data = await controller.machine.update_firmware()
+            assert data["message"] == "OK"


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a `machine` endpoint to handle machine-related functions. Currently, there are three:

1. `controller.machine.get_firmware_update_status`: ask whether there's a firmware update
2. `controller.machine.update_firmware`: request the firmware update
3. `controller.machine.reboot`: reboot the controller

As always, these endpoints are thin wrappers on the API that return JSON; it's up to the consumer to know what to do. Reference: https://rainmachine.docs.apiary.io/#reference/machine

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
