### PR TITLE
Catch JSON errors during requests

### DIFF
--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+import json
 import logging
 import ssl
 from typing import Any
@@ -136,6 +137,8 @@ class Client:
                 _raise_for_remote_status(url, data)
         except ServerDisconnectedError:
             raise
+        except json.decoder.JSONDecodeError as err:
+            raise RequestError("Unable to parse response as JSON") from err
         except ClientError as err:
             if "401" in str(err):
                 raise TokenExpiredError("Long-lived access token has expired") from err
@@ -143,7 +146,7 @@ class Client:
                 f"Error requesting data from {url}: {err} (data: {data})"
             ) from err
         except asyncio.TimeoutError as err:
-            raise RequestError(f"Timmed out while requesting data from {url}") from err
+            raise RequestError(f"Timed out while requesting data from {url}") from err
 
         _LOGGER.debug("Data received for %s: %s", url, data)
 


### PR DESCRIPTION
**Describe what the PR does:**

Controllers can sometimes return unparseable-as-JSON responses (especially with HTTP 4xx error codes). This isn't something we can solve directly, but we can wrap them in appropriate `RequestError` objects.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
