### PR TITLE
Raise new, specific exception on unknown API call

### DIFF
--- a/regenmaschine/errors.py
+++ b/regenmaschine/errors.py
@@ -1,4 +1,10 @@
 """Define package errors."""
+from __future__ import annotations
+
+from typing import Any
+
+from aiohttp import ClientResponse
+from aiohttp.client_exceptions import ClientError
 
 
 class RainMachineError(Exception):
@@ -13,21 +19,71 @@ class RequestError(RainMachineError):
     pass
 
 
-class TokenExpiredError(RainMachineError):
+class TokenExpiredError(RequestError):
     """Define an error for expired access tokens that can't be refreshed."""
 
     pass
 
 
-ERROR_CODES = {1: "The email has not been validated"}
+class UnknownAPICallError(RequestError):
+    """Define an error for an unknown API call."""
+
+    pass
 
 
-def raise_remote_error(error_code: int) -> None:
-    """Raise the appropriate error with a remote error code."""
+class UnvalidatedEmailError(RequestError):
+    """Define an error for unvalidated email addresses."""
+
+    pass
+
+
+LOCAL_ERROR_CODE_EXCEPTION_MAPPING = {
+    2: TokenExpiredError,
+    13: UnknownAPICallError,
+}
+
+REMOTE_ERROR_CODE_EXCEPTION_MAPPING = {
+    1: UnvalidatedEmailError("The email has not been validated"),
+}
+
+
+def _raise_local_api_error(url: str, error_code: int, message: str) -> None:
+    """Raise the appropriate error for a remote error code."""
+    exc: RequestError
     try:
-        error = next((v for k, v in ERROR_CODES.items() if k == error_code))
-        raise RequestError(error)
-    except StopIteration:
-        raise RequestError(
-            f"Unknown remote error code returned: {error_code}"
-        ) from None
+        exc_obj = LOCAL_ERROR_CODE_EXCEPTION_MAPPING[error_code]
+        exc = exc_obj(message)
+    except KeyError:
+        exc = RequestError(
+            f"Unknown error returned for {url}: {error_code} -> {message}"
+        )
+    raise exc
+
+
+def _raise_remote_api_error(url: str, error_code: int) -> None:
+    """Raise the appropriate error for a remote error code."""
+    exc: RequestError
+    try:
+        exc = REMOTE_ERROR_CODE_EXCEPTION_MAPPING[error_code]
+    except KeyError:
+        exc = RequestError(f"Unknown error code returned for {url}: {error_code}")
+    raise exc
+
+
+def raise_for_error(resp: ClientResponse, data: dict[str, Any] | None) -> None:
+    """Raise an error from the remote API if necessary."""
+    if data:
+        if data.get("errorType") and data["errorType"] > 0:
+            # RainMachine's remote cloud uses "errorType" to show errors, so if we find
+            # that, we assume we need to raise a remote error:
+            _raise_remote_api_error(resp.url, data["errorType"])
+
+        if data.get("statusCode") and data["statusCode"] != 200:
+            # RainMachine's local cloud uses "statusCode" to show errors, so if we find
+            # that, we assume we need to raise a local error:
+            _raise_local_api_error(resp.url, data["statusCode"], data["message"])
+    else:
+        try:
+            resp.raise_for_status()
+        except ClientError as err:
+            raise RequestError(f"Error while requesting {resp.url}: {err}") from err

--- a/tests/fixtures/unknown_api_call_response.json
+++ b/tests/fixtures/unknown_api_call_response.json
@@ -1,0 +1,4 @@
+{
+  "statusCode": 13,
+  "message": "API call unknown"
+}


### PR DESCRIPTION
**Describe what the PR does:**

This PR raises a new exception (`UnknownAPICallError`) when that specific response is received from the controller. This is useful for Gen1 controllers.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
