### PR TITLE
Add call to get running zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ async def main() -> None:
             # ...and stop it:
             await controller.zones.stop(1)
 
+            # Get all running zones:
+            programs = await controller.zones.running()
+
             # Get the device name:
             name = await controller.provisioning.device_name
 

--- a/regenmaschine/endpoints/zone.py
+++ b/regenmaschine/endpoints/zone.py
@@ -101,6 +101,15 @@ class Zone(EndpointManager):
 
         return {**results[0], **results[1]}
 
+    async def running(self) -> list[dict[str, Any]]:
+        """Return all running zones.
+
+        Returns:
+            An API response payload.
+        """
+        data = await self.controller.request("get", "watering/zone")
+        return cast(list[dict[str, Any]], data["zones"])
+
     async def start(self, zone_id: int, time: int) -> dict[str, Any]:
         """Start a zone.
 

--- a/tests/fixtures/watering_zone_response.json
+++ b/tests/fixtures/watering_zone_response.json
@@ -1,0 +1,136 @@
+{
+  "zones": [
+    {
+      "uid": 1,
+      "name": "Zone 1",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 2,
+      "name": "Zone 2",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 3,
+      "name": "Zone 3",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 4,
+      "name": "Zone 4",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 5,
+      "name": "Zone 5",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 6,
+      "name": "Zone 6",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 7,
+      "name": "Zone 7",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 8,
+      "name": "Zone 8",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 9,
+      "name": "Zone 9",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 10,
+      "name": "Zone 10",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 11,
+      "name": "Zone 11",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    },
+    {
+      "uid": 12,
+      "name": "Zone 12",
+      "state": 0,
+      "userDuration": 0,
+      "machineDuration": 0,
+      "remaining": 0,
+      "cycle": 0,
+      "noOfCycles": 0,
+      "restriction": false
+    }
+  ]
+}


### PR DESCRIPTION
**Describe what the PR does:**

We had `controller.programs.running()`, but were missing `controller.zones.running()`—this PR adds it.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/regenmaschine/issues/158

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
