### PR TITLE
Allow connections to Gen1 controllers when using OpenSSL 3.0+

### DIFF
--- a/regenmaschine/client.py
+++ b/regenmaschine/client.py
@@ -47,10 +47,12 @@ class Client:
         #   2. We utilize the "DEFAULT" cipher suite (which includes old RSA ciphers).
         #   3. We don't validate the hostname.
         #   4. We allow self-signed certificates.
+        #   5. We allow legacy server connections.
         self._ssl_context.minimum_version = ssl.TLSVersion.SSLv3
         self._ssl_context.set_ciphers("DEFAULT")
         self._ssl_context.check_hostname = False
         self._ssl_context.verify_mode = ssl.CERT_NONE
+        self._ssl_context.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0x4)
 
         self.controllers: dict[str, Controller] = {}
 


### PR DESCRIPTION
**Describe what the PR does:**

SSIA. Inspiration from @bdraco via https://github.com/gwww/elkm1/pull/69.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
